### PR TITLE
Add support for reading recarray healsparse maps

### DIFF
--- a/healsparse/_version.py
+++ b/healsparse/_version.py
@@ -1,2 +1,2 @@
-__version__ = '0.0.2'
+__version__ = '0.0.3'
 __version_info__ = tuple(map(int, __version__.split('.')))

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -17,9 +17,9 @@ class HealSparseMap(object):
             self._covIndexMap = covIndexMap
             self._sparseMap = sparseMap
         elif healpixMap is not None and nsideCoverage is not None:
-            # this is a healpxMap input
+            # this is a healpixMap input
             self._covIndexMap, self._sparseMap = self.convertHealpixMap(healpixMap,
-                                                                   nsideCoverage=nsideCoverage, nest=nest)
+                                                                        nsideCoverage=nsideCoverage, nest=nest)
             nsideSparse = hp.npix2nside(healpixMap.size)
         else:
             raise RuntimeError("Must specify either covIndexMap/sparseMap or healpixMap/nsideCoverage")
@@ -27,11 +27,12 @@ class HealSparseMap(object):
         self._nsideCoverage = hp.npix2nside(self._covIndexMap.size)
         self._nsideSparse = nsideSparse
 
-        # FIXME: check if _sparseMap is a recarray!
         self._isRecArray = False
-        if primary is not None:
-            self._primary = primary
+        self._primary = primary
+        if self._sparseMap.dtype.fields is not None:
             self._isRecArray = True
+            if self._primary is None:
+                raise RuntimeError("Must specify `primary` field when using a recarray for the sparseMap.")
 
         self._bitShift = 2 * int(np.round(np.log(self._nsideSparse / self._nsideCoverage) / np.log(2)))
 

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -43,7 +43,15 @@ class HealSparseMap(object):
                 raise RuntimeError("Must specify nsideCoverage when reading healpix map")
 
             # This is a healpix format
-            healpixMap = hp.read_map(filename, nest=True, verbose=False)
+            # We need to determine the datatype, preserving it.
+            if hdr['OBJECT'].rstrip() == 'PARTIAL':
+                row = fitsio.read(filename, ext=1, rows=[0])
+                dtype = row[0]['SIGNAL'].dtype.type
+            else:
+                row = fitsio.read(filename, ext=1, rows=[0])
+                dtype = row[0]['T'][0].dtype.type
+
+            healpixMap = hp.read_map(filename, nest=True, verbose=False, dtype=dtype)
             return cls(healpixMap=healpixMap, nsideCoverage=nsideCoverage, nest=True)
         elif 'PIXTYPE' in hdr and hdr['PIXTYPE'].rstrip() == 'HEALSPARSE':
             # This is a sparse map type.  Just use fits for now.

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -56,7 +56,7 @@ class HealSparseMap(object):
                 dtype = row[0]['SIGNAL'].dtype.type
             else:
                 row = fitsio.read(filename, ext=1, rows=[0])
-                dtype = row[0]['T'][0].dtype.type
+                dtype = row[0][0][0].dtype.type
 
             healpixMap = hp.read_map(filename, nest=True, verbose=False, dtype=dtype)
             return cls(healpixMap=healpixMap, nsideCoverage=nsideCoverage, nest=True)

--- a/tests/test_coverageMap.py
+++ b/tests/test_coverageMap.py
@@ -18,27 +18,28 @@ class CoverageMapTestCase(unittest.TestCase):
         non_masked_px = 10 # Number of non-masked pixels in the coverage map resolution
         nfine = (nsideMap//nsideCoverage)**2
         fullMap = np.zeros(hp.nside2npix(nsideMap)) + hp.UNSEEN
-        fullMap[0:non_masked_px*nfine] = 1+np.random.random(size=non_masked_px*nfine)       
-        
+        fullMap[0:non_masked_px*nfine] = 1+np.random.random(size=non_masked_px*nfine)
+
         # Generate sparse map
 
         sparseMap = healsparse.HealSparseMap(healpixMap=fullMap, nsideCoverage=nsideCoverage)
-        
+
         # Build the "original" coverage map
 
         covMap_orig = np.zeros(hp.nside2npix(nsideCoverage), dtype=np.double)
         idx_cov = np.right_shift(np.arange(0,non_masked_px*nfine), sparseMap._bitShift)
         unique_idx_cov = np.unique(idx_cov)
-        idx_counts = np.bincount(idx_cov, minlength=hp.nside2npix(nsideCoverage)).astype(float) 
-        covMap_orig[unique_idx_cov] = idx_counts[unique_idx_cov]/nfine 
-        
+        idx_counts = np.bincount(idx_cov, minlength=hp.nside2npix(nsideCoverage)).astype(float)
+
+        covMap_orig[unique_idx_cov] = idx_counts[unique_idx_cov]/nfine
+
         # Get the built coverage map
 
         covMap = sparseMap.coverageMap
 
 
         # Test the coverage map generation and lookup
-        
+
         testing.assert_equal(covMap_orig, covMap)
 
 if __name__=='__main__':

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -42,7 +42,7 @@ class IoTestCase(unittest.TestCase):
         # Save it with healpy in ring
 
         fullMapRing = hp.reorder(fullMap, n2r=True)
-        hp.write_map(os.path.join(self.test_dir, 'healpix_map_ring.fits'), fullMapRing)
+        hp.write_map(os.path.join(self.test_dir, 'healpix_map_ring.fits'), fullMapRing, dtype=np.float64)
 
         # Read it with healsparse
         # TODO Test that we raise an exception when nsideCoverage isn't set
@@ -53,10 +53,10 @@ class IoTestCase(unittest.TestCase):
         testing.assert_almost_equal(sparseMap.getValuePixel(ipnest), testValues)
 
         # Save map to healpy in nest
-        hp.write_map(os.path.join(self.test_dir, 'healpix_map_nest.fits'), fullMap)
+        hp.write_map(os.path.join(self.test_dir, 'healpix_map_nest.fits'), fullMap, dtype=np.float64, nest=True)
 
         # Read it with healsparse
-        sparseMap = healsparse.HealSparseMap.read(os.path.join(self.test_dir, 'healpix_map_ring.fits'), nsideCoverage=nsideCoverage)
+        sparseMap = healsparse.HealSparseMap.read(os.path.join(self.test_dir, 'healpix_map_nest.fits'), nsideCoverage=nsideCoverage)
 
         # Check that we can do a basic lookup
         testing.assert_almost_equal(sparseMap.getValuePixel(ipnest), testValues)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -31,7 +31,7 @@ class IoTestCase(unittest.TestCase):
         # Generate a random map
 
         fullMap = np.zeros(hp.nside2npix(nsideMap)) + hp.UNSEEN
-        fullMap[0:20000] = np.random.random(size=20000)
+        fullMap[0: 20000] = np.random.random(size=20000)
 
         theta = np.radians(90.0 - dec)
         phi = np.radians(ra)

--- a/tests/test_recarray.py
+++ b/tests/test_recarray.py
@@ -1,0 +1,84 @@
+from __future__ import division, absolute_import, print_function
+
+import unittest
+import numpy.testing as testing
+import numpy as np
+import healpy as hp
+from numpy import random
+import tempfile
+import shutil
+import os
+import fitsio
+
+import healsparse
+
+class RecArrayTestCase(unittest.TestCase):
+    def test_readRecarray(self):
+        """
+        Test recarray reading.  (Because writing hasn't been written yet.)
+        """
+
+        random.seed(seed=12345)
+
+        nsideCoverage = 32
+        nsideMap = 64
+
+        nRand = 1000
+        ra = np.random.random(nRand) * 360.0
+        dec = np.random.random(nRand) * 180.0 - 90.0
+
+        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
+
+        # Generate a random map...
+
+        column1 = np.zeros(hp.nside2npix(nsideMap)) + hp.UNSEEN
+        column1[0: 20000] = np.random.random(size=20000)
+
+        column2 = np.zeros(hp.nside2npix(nsideMap)) + hp.UNSEEN
+        column2[0: 20000] = np.random.random(size=20000)
+
+        theta = np.radians(90.0 - dec)
+        phi = np.radians(ra)
+        ipnest = hp.ang2pix(nsideMap, theta, phi, nest=True)
+
+        testValues1 = column1[ipnest]
+        testValues2 = column2[ipnest]
+
+        # create a map by hand
+        covIndexMap, sparseMap1 = healsparse.HealSparseMap.convertHealpixMap(column1, nsideCoverage)
+        _, sparseMap2 = healsparse.HealSparseMap.convertHealpixMap(column2, nsideCoverage)
+
+        cHdr = fitsio.FITSHDR()
+        cHdr['PIXTYPE'] = 'HEALSPARSE'
+        cHdr['NSIDE'] = nsideCoverage
+        fitsio.write(os.path.join(self.test_dir, 'healsparse_map_recarray.fits'), covIndexMap, header=cHdr, extname='COV', clobber=True)
+
+        sHdr = fitsio.FITSHDR()
+        sHdr['PIXTYPE'] = 'HEALSPARSE'
+        sHdr['NSIDE'] = nsideMap
+        sHdr['PRIMARY'] = 'column1'
+
+        recArray = np.zeros(sparseMap1.size, dtype=[('column1', 'f8'),
+                                                    ('column2', 'f8')])
+        recArray['column1'][:] = sparseMap1
+        recArray['column2'][:] = sparseMap2
+        fitsio.write(os.path.join(self.test_dir, 'healsparse_map_recarray.fits'), recArray, header=sHdr, extname='SPARSE')
+
+        sparseMap = healsparse.HealSparseMap.read(os.path.join(self.test_dir, 'healsparse_map_recarray.fits'))
+
+        testing.assert_almost_equal(sparseMap.getValuePixel(ipnest)['column1'], testValues1)
+        testing.assert_almost_equal(sparseMap.getValuePixel(ipnest)['column2'], testValues2)
+
+
+
+    def setUp(self):
+        self.test_dir = None
+
+    def tearDown(self):
+        if self.test_dir is not None:
+            if os.path.exists(self.test_dir):
+                shutil.rmtree(self.test_dir, True)
+
+if __name__=='__main__':
+    unittest.main()
+

--- a/tests/test_recarray.py
+++ b/tests/test_recarray.py
@@ -69,7 +69,25 @@ class RecArrayTestCase(unittest.TestCase):
         testing.assert_almost_equal(sparseMap.getValuePixel(ipnest)['column1'], testValues1)
         testing.assert_almost_equal(sparseMap.getValuePixel(ipnest)['column2'], testValues2)
 
+        # And read a partial map
+        sparseMapSmall = healsparse.HealSparseMap.read(os.path.join(self.test_dir, 'healsparse_map_recarray.fits'), pixels=[0, 1])
 
+        # Test the coverage map only has two pixels
+        covMask = sparseMapSmall.coverageMask
+        self.assertEqual(covMask.sum(), 2)
+
+        # Test lookup of values in these two pixels
+        ipnestCov = np.right_shift(ipnest, sparseMapSmall._bitShift)
+        outsideSmall, = np.where(ipnestCov > 1)
+        # column1 is the "primary" column and will return UNSEEN
+        testValues1b = testValues1.copy()
+        testValues1b[outsideSmall] = hp.UNSEEN
+        # column2 is not the primary column and will return 0s (unfilled)
+        testValues2b = testValues2.copy()
+        testValues2b[outsideSmall] = hp.UNSEEN
+
+        testing.assert_almost_equal(sparseMapSmall.getValuePixel(ipnest)['column1'], testValues1b)
+        testing.assert_almost_equal(sparseMapSmall.getValuePixel(ipnest)['column2'], testValues2b)
 
     def setUp(self):
         self.test_dir = None


### PR DESCRIPTION
The good news is this can read recarray maps.  The bad news is that there's no real facility for writing them yet.  That's to come.
This also changes the overflow bins to the beginning, so that makes building and appending maps easier.