### PR TITLE
Added downgrade functionality

### DIFF
--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -358,7 +358,7 @@ class HealSparseMap(object):
 
         pass
  
-    def degrade(self, nside_out, reduction='mean', primary=None):
+    def degrade(self, nside_out, reduction='mean'):
         """
         Reduce the resolution, i.e., increase the pixel size
         of a given sparse map
@@ -367,7 +367,6 @@ class HealSparseMap(object):
         ----
         nside_out: `int`, output Nside resolution parameter.
         reduction: `str`, reduction method (mean, median, std, max, min).
-        primary: `str`, in the case of using `np.recarray`, name of the field to use.
         """ 
         
         if self._nsideSparse < nside_out:
@@ -430,5 +429,5 @@ class HealSparseMap(object):
         newIndexMap[self.coverageMask] = np.arange(1, npop_pix + 1) * nFinePerCov
         newIndexMap[:] -= np.arange(hp.nside2npix(self._nsideCoverage), dtype=np.int64) * nFinePerCov
         return HealSparseMap(covIndexMap=newIndexMap, sparseMap=newsparseMap, nsideCoverage=self._nsideCoverage,
-                   nsideSparse=nside_out, primary=primary) 
+                   nsideSparse=nside_out, primary=self._primary) 
 

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -1,5 +1,4 @@
 from __future__ import division, absolute_import, print_function
-
 import numpy as np
 import healpy as hp
 import fitsio
@@ -370,31 +369,66 @@ class HealSparseMap(object):
         reduction: `str`, reduction method (mean, median, std, max, min).
         primary: `str`, in the case of using `np.recarray`, name of the field to use.
         """ 
+        
         if self._nsideSparse < nside_out:
             raise ValueError('nside_out should be smaller than nside for the sparseMap')
         # Count the number of filled pixels in the coverage mask
         npop_pix = np.count_nonzero(self.coverageMask)
-        # Mask unseen pixels
-        newsparseMap = self._sparseMap
+        # We need the new bitShifts and we have to build a new CovIndexMap
+        bitShift = 2 * int(np.round(np.log(nside_out / self._nsideCoverage) / np.log(2)))
+        nFinePerCov = 2**bitShift 
+        # Work with RecArray (we have to change the resolution to all maps...)
         if self._isRecArray:
-            newsparseMap[newsparseMap[primary]==hp.UNSEEN] = np.nan
+            dtype = self._sparseMap.dtype
+            # Allocate new map
+            newsparseMap = np.zeros((npop_pix+1)*nFinePerCov, dtype=dtype)
+            for key, value in newsparseMap.dtype.fields.items():  
+                aux = self._sparseMap[key]
+                aux = aux.reshape((npop_pix+1, (nside_out//self._nsideCoverage)**2, -1))
+                wgt = np.ones_like(aux, dtype=np.float)
+                # We avoid setting the overflow bins to zero weight
+                wgt[1,:,:][aux[1,:,:]==hp.UNSEEN] = 0. 
+                if reduction=='mean':
+                    aux = np.average(aux, weights=wgt, axis=2).flatten()
+                elif reduction=='max':
+                    aux = np.max(aux, axis=2).flatten()
+                elif reduction=='min':
+                    aux[aux==hp.UNSEEN]=-hp.UNSEEN
+                    aux = np.min(aux, axis=2).flatten()
+                elif reduction=='std':
+                    avg = np.average(aux, weights=wgt, axis=2).flatten()
+                    avg2 = np.average(aux**2, weights=wgt, axis=2).flatten()
+                    aux = np.sqrt(avg2 - avg**2)
+                elif reduction=='median':
+                    raise ValueError('Median not yet implemented for recarray')
+                else:
+                    raise ValueError('Only mean, max, std, and min implemented for recarray') 
+                newsparseMap[key] = aux
+        # Work with ndarray
         else:
-            newsparseMap[newsparseMap==hp.UNSEEN] = np.nan
-        newsparseMap = newsparseMap.reshape((npop_pix+1, (nside_out//self._nsideCoverage)**2, -1))
-        # Reduce array
-        if reduction=='mean':
-            newsparseMap = np.nanmean(newsparseMap, axis=2).flatten()
-        elif reduction=='median':
-            newsparseMap = np.nanmedian(newsparseMap, axis=2).flatten()
-        elif reduction=='std':
-            newsparseMap = np.nanstd(newsparseMap, axis=2).flatten()
-        elif reduction=='max':
-            newsparseMap = np.nanmax(newsparseMap, axis=2).flatten()
-        elif reduction=='min':
-            newsparseMap = np.nanmin(newsparseMap, axis=2).flatten()
-        else:
-            raise ValueError('Only mean, median, std, max, and min reductions implemented')
-        # NaN are converted to UNSEEN
-        newsparseMap[np.isnan(newsparseMap)]=hp.UNSEEN
-        return HealSparseMap(self._covIndexMap, sparseMap=newsparseMap, nsideSparse=nside_out, nsideCoverage=self._nsideCoverage, primary=primary)
+            aux = self._sparseMap
+            aux = aux.reshape((npop_pix+1, (nside_out//self._nsideCoverage)**2, -1))
+            aux[aux==hp.UNSEEN] = np.nan
+            # Reduce array
+            if reduction=='mean':
+                aux = np.nanmean(aux, axis=2).flatten()
+            elif reduction=='median':
+                aux = np.nanmedian(aux, axis=2).flatten()
+            elif reduction=='std':
+                aux = np.nanstd(aux, axis=2).flatten()
+            elif reduction=='max':
+                aux = np.nanmax(aux, axis=2).flatten()
+            elif reduction=='min':
+                aux = np.nanmin(aux, axis=2).flatten()
+            else:
+                raise ValueError('Only mean, median, std, max, and min reductions implemented')
+            # NaN are converted to UNSEEN
+            aux[np.isnan(aux)]=hp.UNSEEN
+            newsparseMap = aux
+        # The coverage index map is now offset, we have to build a new one
+        newIndexMap = np.zeros(hp.nside2npix(self._nsideCoverage), dtype=np.int64)
+        newIndexMap[self.coverageMask] = np.arange(1, npop_pix + 1) * nFinePerCov
+        newIndexMap[:] -= np.arange(hp.nside2npix(self._nsideCoverage), dtype=np.int64) * nFinePerCov
+        return HealSparseMap(covIndexMap=newIndexMap, sparseMap=newsparseMap, nsideCoverage=self._nsideCoverage,
+                   nsideSparse=nside_out, primary=primary) 
 

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -378,6 +378,13 @@ class HealSparseMap(object):
         nFinePerCov = 2**bitShift 
         # Work with RecArray (we have to change the resolution to all maps...)
         if self._isRecArray:
+            dtype = []
+            # We should avoid integers
+            for key, value in self._sparseMap.dtype.fields.items():
+                if isinstance(self._sparseMap[key],int):
+                    dtype.append((key,np.float))
+                else:
+                    dtype.append((key,value[0]))
             dtype = self._sparseMap.dtype
             # Allocate new map
             newsparseMap = np.zeros((npop_pix+1)*nFinePerCov, dtype=dtype)

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -262,3 +262,17 @@ class HealSparseMap(object):
 
         pass
 
+    def degrade(self, nside_out, reduction='mean'):
+        """
+        Reduce the resolution, i.e., increase the pixel size
+        of a given sparse map
+        """
+        try:
+           assert(self._nsideSparse > nside_out)
+        except ValueError as e:
+           print('nside_out should be smaller than nside for the sparseMap')
+        npop_pix = np.count_nonzero(self.coverageMask)
+        self._sparseMap[self._sparseMap==hp.UNSEEN] = np.nan
+        self._sparseMap = np.nanmean(self._sparseMap.reshape((npop_pix+1, (nside_out//self._nsideCoverage)**2, -1)), axis=2).flatten()
+        self._nsideSparse = nside_out
+        self._bitShift = 2 * int(np.round(np.log(self._nsideSparse / self._nsideCoverage) / np.log(2)))

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -261,30 +261,28 @@ class HealSparseMap(object):
         """
 
         pass
-
-    @classmethod
-    def degrade(cls, sparseMap, nside_out, reduction='mean'):
+ 
+    def degrade(self, nside_out, reduction='mean'):
         """
         Reduce the resolution, i.e., increase the pixel size
         of a given sparse map
         
         Args:
         ----
-        sparseMap: `HealSparseMap`, sparse map to degrade
-        nside_out: `int`, output Nside resolution parameter
-        """
-
-        if sparseMap._nsideSparse < nside_out:
+        nside_out: `int`, output Nside resolution parameter.
+        reduction: `str`, reduction method (mean, median, std, max, min).
+        """ 
+        if self._nsideSparse < nside_out:
             raise ValueError('nside_out should be smaller than nside for the sparseMap')
         # Count the number of filled pixels in the coverage mask
-        npop_pix = np.count_nonzero(sparseMap.coverageMask)
+        npop_pix = np.count_nonzero(self.coverageMask)
         # Mask unseen pixels
-        newsparseMap = sparseMap._sparseMap
-        if sparseMap._isRecArray:
-            newsparseMap[newsparseMap[sparseMap._primary]==hp.UNSEEN] = np.nan
+        newsparseMap = self._sparseMap
+        if self._isRecArray:
+            newsparseMap[newsparseMap[self._primary]==hp.UNSEEN] = np.nan
         else:
             newsparseMap[newsparseMap==hp.UNSEEN] = np.nan
-        newsparseMap = newsparseMap.reshape((npop_pix+1, (nside_out//sparseMap._nsideCoverage)**2, -1))
+        newsparseMap = newsparseMap.reshape((npop_pix+1, (nside_out//self._nsideCoverage)**2, -1))
         # Reduce array
         if reduction=='mean':
             newsparseMap = np.nanmean(newsparseMap, axis=2).flatten()
@@ -292,7 +290,11 @@ class HealSparseMap(object):
             newsparseMap = np.nanmedian(newsparseMap, axis=2).flatten()
         elif reduction=='std':
             newsparseMap = np.nanstd(newsparseMap, axis=2).flatten()
+        elif reduction=='max':
+            newsparseMap = np.nanmax(newsparseMap, axis=2).flatten()
+        elif reduction=='min':
+            newsparseMap = np.nanmin(newsparseMap, axis=2).flatten()
         else:
-            raise ValueError('Only mean, median and std reductions implemented')
-        return cls(sparseMap._covIndexMap, sparseMap=newsparseMap, nsideSparse=nside_out, nsideCoverage=sparseMap._nsideCoverage, primary=sparseMap._primary)
+            raise ValueError('Only mean, median, std, max, and min reductions implemented')
+        return HealSparseMap(self._covIndexMap, sparseMap=newsparseMap, nsideSparse=nside_out, nsideCoverage=self._nsideCoverage, primary=self._primary)
 

--- a/healsparse/utils.py
+++ b/healsparse/utils.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+def reduce_array(x, reduction='mean', axis=2):
+    """
+    Auxiliary method to perform one of the following operations:
+    nanmean, nanmax, nanmedian, nanmin, nanstd
+
+    Args:
+    ----
+    x: `ndarray`, input array in which to perform the operation
+    reduction: `str`, reduction method. Valid options: mean, median, std, max, min
+               (default: mean).
+    axis: `int`, axis in which to perform the operation (default: 2)
+
+    Returns:
+    --------
+    out: `ndarray`.
+    """
+    if reduction=='mean':
+        return np.nanmean(x, axis=2).flatten()
+    elif reduction=='median':
+        return np.nanmedian(x, axis=2).flatten()
+    elif reduction=='std':
+        return np.nanstd(x, axis=2).flatten()
+    elif reduction=='max':
+        return np.nanmax(x, axis=2).flatten()
+    elif reduction=='min':
+        return np.nanmin(x, axis=2).flatten()
+    else:
+        raise ValueError('Reduction method %s not recognized.' % reduction)

--- a/tests/test_degrade.py
+++ b/tests/test_degrade.py
@@ -8,9 +8,9 @@ from numpy import random
 import healsparse
 
 class DegradeMapTestCase(unittest.TestCase):
-    def test_degradeMap(self):
+    def test_degradeMapFloat(self):
         """
-        Test HealSparse.degrade functionality
+        Test HealSparse.degrade functionality with float quantities
         """
         random.seed(12345)
         nsideCoverage = 32
@@ -34,6 +34,46 @@ class DegradeMapTestCase(unittest.TestCase):
         # Test the coverage map generation and lookup
 
         testing.assert_equal(deg_map, newMap._sparseMap[2**newMap._bitShift:])
+
+    def test_degradeMapRecArray(self):
+        """
+        Test HealSparse.degrade functionality with recarray quantities
+        """
+        
+        random.seed(seed=12345)
+
+        nsideCoverage = 32
+        nsideMap = 1024
+        nsideNew = 256
+
+        nRand = 1000
+        ra = np.random.random(nRand) * 360.0
+        dec = np.random.random(nRand) * 180.0 - 90.0
+
+        dtype = [('col1', 'f8'), ('col2', 'f8')]
+        sparseMap = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, dtype, primary='col1')
+        pixel = np.arange(20000)
+        values = np.zeros_like(pixel, dtype=dtype)
+        values['col1'] = np.random.random(size=pixel.size)
+        values['col2'] = np.random.random(size=pixel.size)
+        sparseMap.updateValues(pixel, values)
+   
+        # Make the test values
+        hpmapCol1 = np.zeros(hp.nside2npix(nsideMap)) + hp.UNSEEN
+        hpmapCol2 = np.zeros(hp.nside2npix(nsideMap)) + hp.UNSEEN
+        hpmapCol1[pixel] = values['col1']
+        hpmapCol2[pixel] = values['col2']
+        theta = np.radians(90.0 - dec)
+        phi = np.radians(ra)
+        # Degrade healpix maps
+        hpmapCol1 = hp.ud_grade(hpmapCol1, nside_out=nsideNew, order_in='NESTED', order_out='NESTED')
+        hpmapCol2 = hp.ud_grade(hpmapCol2, nside_out=nsideNew, order_in='NESTED', order_out='NESTED')
+        ipnestTest = hp.ang2pix(nsideNew, theta, phi, nest=True) 
+
+        # Degrade the old map
+        newSparseMap = sparseMap.degrade(nside_out=nsideNew, primary='col1')
+        testing.assert_almost_equal(newSparseMap.getValueRaDec(ra, dec)['col1'], hpmapCol1[ipnestTest])
+        testing.assert_almost_equal(newSparseMap.getValueRaDec(ra, dec)['col2'], hpmapCol2[ipnestTest])
 
 if __name__=='__main__':
     unittest.main()

--- a/tests/test_degrade.py
+++ b/tests/test_degrade.py
@@ -20,19 +20,20 @@ class DegradeMapTestCase(unittest.TestCase):
 
         # Generate sparse map
 
-        sparseMap = healsparse.HealSparseMap(healpixMap=fullMap, nsideCoverage=nsideCoverage)
-        
+        sparseMap = healsparse.HealSparseMap(healpixMap=fullMap, nsideCoverage=nsideCoverage,
+                        nsideSparse=nsideMap)
+         
         # Degrade original HEALPix map
 
         deg_map = hp.ud_grade(fullMap, nside_out=nsideNew, order_in='NESTED', order_out='NESTED')
 
         # Degrade sparse map and compare to original
 
-        sparseMap = sparseMap.degrade(sparseMap, nside_out=nsideNew)
+        newMap = sparseMap.degrade(nside_out=nsideNew)
 
         # Test the coverage map generation and lookup
 
-        testing.assert_equal(deg_map, sparseMap._sparseMap[2**sparseMap._bitShift:])
+        testing.assert_equal(deg_map, newMap._sparseMap[2**newMap._bitShift:])
 
 if __name__=='__main__':
     unittest.main()

--- a/tests/test_degrade.py
+++ b/tests/test_degrade.py
@@ -71,7 +71,7 @@ class DegradeMapTestCase(unittest.TestCase):
         ipnestTest = hp.ang2pix(nsideNew, theta, phi, nest=True) 
 
         # Degrade the old map
-        newSparseMap = sparseMap.degrade(nside_out=nsideNew, primary='col1')
+        newSparseMap = sparseMap.degrade(nside_out=nsideNew)
         testing.assert_almost_equal(newSparseMap.getValueRaDec(ra, dec)['col1'], hpmapCol1[ipnestTest])
         testing.assert_almost_equal(newSparseMap.getValueRaDec(ra, dec)['col2'], hpmapCol2[ipnestTest])
 

--- a/tests/test_degrade.py
+++ b/tests/test_degrade.py
@@ -1,0 +1,38 @@
+from __future__ import division, absolute_import, print_function
+
+import unittest
+import numpy.testing as testing
+import numpy as np
+import healpy as hp
+from numpy import random
+import healsparse
+
+class DegradeMapTestCase(unittest.TestCase):
+    def test_degradeMap(self):
+        """
+        Test HealSparse.degrade functionality
+        """
+        random.seed(12345)
+        nsideCoverage = 32
+        nsideMap = 1024
+        nsideNew = 256
+        fullMap = random.random(hp.nside2npix(nsideMap))
+
+        # Generate sparse map
+
+        sparseMap = healsparse.HealSparseMap(healpixMap=fullMap, nsideCoverage=nsideCoverage)
+        
+        # Degrade original HEALPix map
+
+        deg_map = hp.ud_grade(fullMap, nside_out=nsideNew, order_in='NESTED', order_out='NESTED')
+
+        # Degrade sparse map and compare to original
+
+        sparseMap.degrade(nside_out=nsideNew)
+
+        # Test the coverage map generation and lookup
+
+        testing.assert_equal(deg_map, sparseMap._sparseMap[2**sparseMap._bitShift:])
+
+if __name__=='__main__':
+    unittest.main()

--- a/tests/test_degrade.py
+++ b/tests/test_degrade.py
@@ -28,7 +28,7 @@ class DegradeMapTestCase(unittest.TestCase):
 
         # Degrade sparse map and compare to original
 
-        sparseMap.degrade(nside_out=nsideNew)
+        sparseMap = sparseMap.degrade(sparseMap, nside_out=nsideNew)
 
         # Test the coverage map generation and lookup
 


### PR DESCRIPTION
I added the downgrade functionality but I made a lot of design choices (e.g, I subbed the `hp.UNSEEN` values by `np.nan` to then calculate the mean). I also decided that this modifies the original `sparseMap`, `nsideSparse` and `bitShift` attributes. Please, let me know if you agree with these choices or you would prefer to expose the method and put a `sparseMap` as input and return a `sparseMap` rather than modifying the original.