### PR TITLE
Add map composing operations (sum, product, and, or, etc)

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,7 +1,7 @@
 Quickstart
 ==========
 
-A `jupyter notebook <http://jupyter-notebook.readthedocs.io/en/latest/>`_ is available for tutorial purposes 
-`here <https://github.com/LSSTDESC/healsparse/master/tutorial/quickstart.ipynb>`_
+A `jupyter notebook <http://jupyter-notebook.readthedocs.io/en/latest/>`_ is available for tutorial purposes
+`here <../tutorial/quickstart.ipynb>`_
 
 

--- a/healsparse/__init__.py
+++ b/healsparse/__init__.py
@@ -1,3 +1,8 @@
 from .healSparseMap import HealSparseMap
 from .healSparseRandoms import makeUniformRandoms
 from .operations import sumUnion, sumIntersection
+from .operations import productUnion, productIntersection
+from .operations import orUnion, orIntersection
+from .operations import andUnion, andIntersection
+from .operations import xorUnion, xorIntersection
+

--- a/healsparse/__init__.py
+++ b/healsparse/__init__.py
@@ -1,2 +1,3 @@
 from .healSparseMap import HealSparseMap
 from .healSparseRandoms import makeUniformRandoms
+from .operations import sumUnion, sumIntersection

--- a/healsparse/_version.py
+++ b/healsparse/_version.py
@@ -1,2 +1,2 @@
-__version__ = '0.0.6'
+__version__ = '0.0.7'
 __version_info__ = tuple(map(int, __version__.split('.')))

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -957,7 +957,7 @@ class HealSparseMap(object):
         descr = 'HealSparseMap: nsideCoverage = %d, nsideSparse = %d' % (self._nsideCoverage, self._nsideSparse)
         if self._isRecArray:
             descr += ', record array type.\n'
-            descr += self._sparseMap.dtype.descr
+            descr += self._sparseMap.dtype.descr.__str__()
         else:
             descr += ', ' + self._sparseMap.dtype.name
         return descr

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -915,10 +915,10 @@ class HealSparseMap(object):
         name = func.__str__()
 
         if self._isRecArray:
-            raise NotImplemented("Cannot use %s with recarray maps" % (name))
+            raise NotImplementedError("Cannot use %s with recarray maps" % (name))
         if intOnly:
             if not issubclass(self._sparseMap.dtype.type, np.integer):
-                raise NotImplemented("Can only apply %s to integer maps" % (name))
+                raise NotImplementedError("Can only apply %s to integer maps" % (name))
 
         otherInt = False
         otherFloat = False
@@ -930,10 +930,10 @@ class HealSparseMap(object):
             otherFloat = True
 
         if not otherInt and not otherFloat:
-            raise NotImplemented("Can only use a constant with the %s operation" % (name))
+            raise NotImplementedError("Can only use a constant with the %s operation" % (name))
 
         if not otherInt and intOnly:
-            raise NotImplemented("Can only use an integer constant with the %s operation" % (name))
+            raise NotImplementedError("Can only use an integer constant with the %s operation" % (name))
 
         validSparsePixels = (self._sparseMap > self._sentinel)
         if inPlace:

--- a/healsparse/operations.py
+++ b/healsparse/operations.py
@@ -43,7 +43,159 @@ def sumIntersection(mapList):
 
     return _applyOperation(mapList, np.add, 0, union=False)
 
-def _applyOperation(mapList, func, fillerValue, union=False):
+def productUnion(mapList):
+    """
+    Compute the product of a list of HealSparseMaps as a union.  Empty values
+    will be treated as 1s in the product, and the output map will have a
+    union of all the input map pixels.
+
+    Parameters
+    ----------
+    mapList: `list` of `HealSparseMap`
+       Input list of maps to take the product
+
+    Returns
+    -------
+    result: `HealSparseMap`
+       Product of maps
+    """
+
+    return _applyOperation(mapList, np.multiply, 1.0, union=True)
+
+def productIntersection(mapList):
+    """
+    Compute the product of a list of HealSparseMaps as an intersection.  Only
+    pixels that are valid in all the input maps will have valid values in the
+    output.
+
+    Parameters
+    ----------
+    mapList: `list` of `HealSparseMap`
+       Input list of maps to take the product
+
+    Returns
+    -------
+    result: `HealSparseMap`
+       Product of maps
+    """
+
+    return _applyOperation(mapList, np.multiply, 1.0, union=False)
+
+def orUnion(mapList):
+    """
+    Bitwise or a list of HealSparseMaps as a union.  Empty values will be
+    treated as 0s in the bitwise or, and the output map will have a union of all
+    the input map pixels.  Only works in integer maps.
+
+    Parameters
+    ----------
+    mapList: `list` of `HealSparseMap`
+       Input list of maps to bitwise or
+
+    Returns
+    -------
+    result: `HealSparseMap`
+       Bitwise or of maps
+    """
+
+    return _applyOperation(mapList, np.bitwise_or, 0, union=True, intOnly=True)
+
+def orIntersection(mapList):
+    """
+    Bitwise or a list of HealSparseMaps as an intersection.  Only pixels that
+    are valid in all the input maps will have valid values in the output.
+    Only works on integer maps.
+
+    Parameters
+    ----------
+    mapList: `list` of `HealSparseMap`
+       Input list of maps to bitwise or
+
+    Returns
+    -------
+    result: `HealSparseMap`
+       Bitwise or of maps
+    """
+
+    return _applyOperation(mapList, np.bitwise_or, 0, union=False, intOnly=True)
+
+def andUnion(mapList):
+    """
+    Bitwise and a list of HealSparseMaps as a union.  Empty values will be
+    treated as 0s in the bitwise and, and the output map will have a union of all
+    the input map pixels.  Only works in integer maps.
+
+    Parameters
+    ----------
+    mapList: `list` of `HealSparseMap`
+       Input list of maps to bitwise and
+
+    Returns
+    -------
+    result: `HealSparseMap`
+       Bitwise and of maps
+    """
+
+    return _applyOperation(mapList, np.bitwise_and, -1, union=True, intOnly=True)
+
+def andIntersection(mapList):
+    """
+    Bitwise or a list of HealSparseMaps as an intersection.  Only pixels that
+    are valid in all the input maps will have valid values in the output.
+    Only works on integer maps.
+
+    Parameters
+    ----------
+    mapList: `list` of `HealSparseMap`
+       Input list of maps to bitwise and
+
+    Returns
+    -------
+    result: `HealSparseMap`
+       Bitwise and of maps
+    """
+
+    return _applyOperation(mapList, np.bitwise_and, -1, union=False, intOnly=True)
+
+def xorUnion(mapList):
+    """
+    Bitwise xor a list of HealSparseMaps as a union.  Empty values will be
+    treated as 0s in the bitwise or, and the output map will have a union of all
+    the input map pixels.  Only works in integer maps.
+
+    Parameters
+    ----------
+    mapList: `list` of `HealSparseMap`
+       Input list of maps to bitwise xor
+
+    Returns
+    -------
+    result: `HealSparseMap`
+       Bitwise xor of maps
+    """
+
+    return _applyOperation(mapList, np.bitwise_xor, 0, union=True, intOnly=True)
+
+def xorIntersection(mapList):
+    """
+    Bitwise xor a list of HealSparseMaps as an intersection.  Only pixels that
+    are valid in all the input maps will have valid values in the output.
+    Only works on integer maps.
+
+    Parameters
+    ----------
+    mapList: `list` of `HealSparseMap`
+       Input list of maps to bitwise xor
+
+    Returns
+    -------
+    result: `HealSparseMap`
+       Bitwise xor of maps
+    """
+
+    return _applyOperation(mapList, np.bitwise_xor, 0, union=False, intOnly=True)
+
+def _applyOperation(mapList, func, fillerValue, union=False, intOnly=False):
     """
     Apply a generic arithmetic function.
 
@@ -59,6 +211,8 @@ def _applyOperation(mapList, func, fillerValue, union=False):
        Starting value and filler when union is True
     union: `bool`, optional
        Use union mode instead of intersection.  Default is False.
+    intOnly: `bool`, optional
+       Check that input maps are integer types.  Default is False.
 
     Returns
     -------
@@ -77,6 +231,9 @@ def _applyOperation(mapList, func, fillerValue, union=False):
             raise NotImplemented("Can only apply %s to HealSparseMaps" % (name))
         if m._isRecArray:
             raise NotImplemented("Cannot apply %s to recarray maps" % (name))
+        if intOnly:
+            if not issubclass(m._sparseMap.dtype.type, np.integer):
+                raise ValueError("Can only apply %s to integer maps" % (name))
 
         if nsideCoverage is None:
             nsideCoverage = m._nsideCoverage

--- a/healsparse/operations.py
+++ b/healsparse/operations.py
@@ -1,0 +1,160 @@
+from __future__ import division, absolute_import, print_function
+
+import numpy as np
+import healpy as hp
+
+from .utils import reduce_array, checkSentinel
+from .healSparseMap import HealSparseMap
+
+def sumUnion(mapList):
+    """
+    Sum a list of HealSparseMaps as a union.  Empty values will be treated as
+    0s in the summation, and the output map will have a union of all the input
+    map pixels.
+
+    Parameters
+    ----------
+    mapList: `list` of `HealSparseMap`
+       Input list of maps to sum
+
+    Returns
+    -------
+    result: `HealSparseMap`
+       Summation of maps
+    """
+
+    return _applyOperation(mapList, np.add, 0, union=True)
+
+def sumIntersection(mapList):
+    """
+    Sum a list of HealSparseMaps as an intersection.  Only pixels that are valid
+    in all the input maps will have valid values in the output.
+
+    Parameters
+    ----------
+    mapList: `list` of `HealSparseMap`
+       Input list of maps to sum
+
+    Returns
+    -------
+    result: `HealSparseMap`
+       Summation of maps
+    """
+
+    return _applyOperation(mapList, np.add, 0, union=False)
+
+def _applyOperation(mapList, func, fillerValue, union=False):
+    """
+    Apply a generic arithmetic function.
+
+    Cannot be used with recarray maps
+
+    Parameters
+    ----------
+    mapList: `list` of `HealSparseMap`
+       Input list of maps to perform the operation on.
+    func: `np.ufunc`
+       Numpy universal function to apply
+    fillerValue: `int` or `float`
+       Starting value and filler when union is True
+    union: `bool`, optional
+       Use union mode instead of intersection.  Default is False.
+
+    Returns
+    -------
+    result: `HealSparseMap`
+       Resulting map
+    """
+
+    name = func.__str__()
+
+    if len(mapList) < 2:
+        raise RuntimeError("Must supply at least 2 maps to apply %s" % (name))
+
+    nsideCoverage = None
+    for m in mapList:
+        if not isinstance(m, HealSparseMap):
+            raise NotImplemented("Can only apply %s to HealSparseMaps" % (name))
+        if m._isRecArray:
+            raise NotImplemented("Cannot apply %s to recarray maps" % (name))
+
+        if nsideCoverage is None:
+            nsideCoverage = m._nsideCoverage
+            nsideSparse = m._nsideSparse
+            bitShift = m._bitShift
+            dtype = m._sparseMap.dtype
+            sentinel = m._sentinel
+        else:
+            if (nsideCoverage != m._nsideCoverage or
+                nsideSparse != m._nsideSparse):
+                raise RuntimeError("Cannot apply %s to maps with different coverage or map nsides" % (name))
+
+    combinedCovMask = mapList[0].coverageMask
+
+    if union:
+        # Union mode
+        for m in mapList[1: ]:
+            combinedCovMask |= m.coverageMask
+    else:
+        # Intersection mode
+        for m in mapList[1: ]:
+            combinedCovMask &= m.coverageMask
+
+    covPix, = np.where(combinedCovMask)
+
+    if covPix.size == 0:
+        # No coverage ... the result is an empty map
+        return HealSparseMap.makeEmpty(nsideCoverage, nsideSparse, dtype)
+
+    # Initialize the combined map, we know the size
+    nFinePerCov = 2**bitShift
+    covIndexMap = np.zeros(hp.nside2npix(nsideCoverage), dtype=np.int64)
+    covIndexMap[covPix] = np.arange(1, covPix.size + 1) * nFinePerCov
+    covIndexMap[:] -= np.arange(hp.nside2npix(nsideCoverage), dtype=np.int64) * nFinePerCov
+    combinedSparseMap = np.zeros((covPix.size + 1) * nFinePerCov, dtype=dtype) + sentinel
+
+    # Determine which individual pixels might be in the combined map
+    allPixels = None
+    for m in mapList:
+        pixels = np.arange(m._sparseMap.size)
+        covIndex = np.right_shift(pixels, bitShift)
+        pixels -= m._covIndexMap[m.coverageMask][covIndex - 1]
+
+        if allPixels is None:
+            allPixels = pixels.copy()
+        else:
+            allPixels = np.concatenate((allPixels, pixels))
+
+    allPixels = np.unique(allPixels)
+    covIndex = np.right_shift(allPixels, bitShift)
+
+    m = mapList[0]
+    gd = (m._sparseMap[allPixels + m._covIndexMap[covIndex]] > m._sentinel)
+    for m in mapList[1: ]:
+        if union:
+            # Union mode
+            gd |= (m._sparseMap[allPixels + m._covIndexMap[covIndex]] > m._sentinel)
+        else:
+            # Intersection mode
+            gd &= (m._sparseMap[allPixels + m._covIndexMap[covIndex]] > m._sentinel)
+
+    allPixels = allPixels[gd]
+    covIndex = covIndex[gd]
+
+    combinedSparseMap[allPixels + covIndexMap[covIndex]] = fillerValue
+
+    for m in mapList:
+        if union:
+            # Union mode requires tracking bad pixels and replacing them
+            # Note that this is redundant with above.  I don't know if it's better
+            # to cache and take a possible memory hit, or recompute here.
+            gd = (m._sparseMap[allPixels + m._covIndexMap[covIndex]] > m._sentinel)
+            combinedSparseMap[allPixels[gd] + covIndexMap[covIndex[gd]]] = func(combinedSparseMap[allPixels[gd] + covIndexMap[covIndex[gd]]],
+                                                                                m._sparseMap[allPixels[gd] + m._covIndexMap[covIndex[gd]]])
+        else:
+            # Intersection mode we only have good pixels
+            combinedSparseMap[allPixels + covIndexMap[covIndex]] = func(combinedSparseMap[allPixels + covIndexMap[covIndex]],
+                                                                        m._sparseMap[allPixels + m._covIndexMap[covIndex]])
+
+    return HealSparseMap(covIndexMap=covIndexMap, sparseMap=combinedSparseMap, nsideSparse=nsideSparse, sentinel=sentinel)
+

--- a/healsparse/operations.py
+++ b/healsparse/operations.py
@@ -228,9 +228,9 @@ def _applyOperation(mapList, func, fillerValue, union=False, intOnly=False):
     nsideCoverage = None
     for m in mapList:
         if not isinstance(m, HealSparseMap):
-            raise NotImplemented("Can only apply %s to HealSparseMaps" % (name))
+            raise NotImplementedError("Can only apply %s to HealSparseMaps" % (name))
         if m._isRecArray:
-            raise NotImplemented("Cannot apply %s to recarray maps" % (name))
+            raise NotImplementedError("Cannot apply %s to recarray maps" % (name))
         if intOnly:
             if not issubclass(m._sparseMap.dtype.type, np.integer):
                 raise ValueError("Can only apply %s to integer maps" % (name))

--- a/healsparse/utils.py
+++ b/healsparse/utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 import healpy as hp
+import warnings
 
 def reduce_array(x, reduction='mean', axis=2):
     """
@@ -17,18 +18,22 @@ def reduce_array(x, reduction='mean', axis=2):
     --------
     out: `ndarray`.
     """
-    if reduction=='mean':
-        return np.nanmean(x, axis=2).flatten()
-    elif reduction=='median':
-        return np.nanmedian(x, axis=2).flatten()
-    elif reduction=='std':
-        return np.nanstd(x, axis=2).flatten()
-    elif reduction=='max':
-        return np.nanmax(x, axis=2).flatten()
-    elif reduction=='min':
-        return np.nanmin(x, axis=2).flatten()
-    else:
-        raise ValueError('Reduction method %s not recognized.' % reduction)
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', category=RuntimeWarning)
+        if reduction=='mean':
+            ret = np.nanmean(x, axis=2).flatten()
+        elif reduction=='median':
+            ret = np.nanmedian(x, axis=2).flatten()
+        elif reduction=='std':
+            ret = np.nanstd(x, axis=2).flatten()
+        elif reduction=='max':
+            ret = np.nanmax(x, axis=2).flatten()
+        elif reduction=='min':
+            ret =  np.nanmin(x, axis=2).flatten()
+        else:
+            raise ValueError('Reduction method %s not recognized.' % reduction)
+
+    return ret
 
 def checkSentinel(type, sentinel):
     """

--- a/healsparse/utils.py
+++ b/healsparse/utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+import healpy as hp
 
 def reduce_array(x, reduction='mean', axis=2):
     """
@@ -28,3 +29,44 @@ def reduce_array(x, reduction='mean', axis=2):
         return np.nanmin(x, axis=2).flatten()
     else:
         raise ValueError('Reduction method %s not recognized.' % reduction)
+
+def checkSentinel(type, sentinel):
+    """
+    Check if the sentinel value works for the given dtype.
+
+    Parameters
+    ----------
+    type: `type`
+    sentinel: `int`, `float`, or None
+
+    Returns
+    -------
+    Default sentinel if input is None.
+
+    Raises
+    ------
+    ValueError if sentinel is of wrong type
+    """
+
+    if issubclass(type, np.floating):
+        # If we don't have a sentinel, use hp.UNSEEN
+        if sentinel is None:
+            return hp.UNSEEN
+        # If input is a float, we're okay.  Otherwise, Raise.
+        if (issubclass(sentinel.__class__, np.floating) or
+            issubclass(sentinel.__class__, float)):
+            return sentinel
+        else:
+            raise ValueError("Sentinel not of floating type")
+    elif issubclass(type, np.integer):
+        # If we don't have a sentinel, MININT
+        if sentinel is None:
+            return np.iinfo(type).min
+        if (issubclass(sentinel.__class__, np.integer) or
+            issubclass(sentinel.__class__, int)):
+            if (sentinel < np.iinfo(type).min or
+                sentinel > np.iinfo(type).max):
+                raise ValueError("Sentinel out of range of type")
+            return sentinel
+        else:
+            raise ValueError("Sentinel not of integer type")

--- a/tests/test_degrade.py
+++ b/tests/test_degrade.py
@@ -21,8 +21,8 @@ class DegradeMapTestCase(unittest.TestCase):
         # Generate sparse map
 
         sparseMap = healsparse.HealSparseMap(healpixMap=fullMap, nsideCoverage=nsideCoverage,
-                        nsideSparse=nsideMap)
-         
+                                             nsideSparse=nsideMap)
+
         # Degrade original HEALPix map
 
         deg_map = hp.ud_grade(fullMap, nside_out=nsideNew, order_in='NESTED', order_out='NESTED')
@@ -33,13 +33,39 @@ class DegradeMapTestCase(unittest.TestCase):
 
         # Test the coverage map generation and lookup
 
-        testing.assert_equal(deg_map, newMap._sparseMap[2**newMap._bitShift:])
+        testing.assert_almost_equal(deg_map, newMap.generateHealpixMap())
+
+    def test_degradeMapInt(self):
+        """
+        Test HealSparse.degrade functionality with int quantities
+        """
+
+        random.seed(12345)
+        nsideCoverage = 32
+        nsideMap = 1024
+        nsideNew = 256
+        fullMap = random.poisson(size=hp.nside2npix(nsideMap), lam=2)
+
+        # Generate sparse map
+        sparseMap = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, np.int64)
+        sparseMap.updateValues(np.arange(fullMap.size), fullMap)
+
+        # Degrade original HEALPix map
+
+        deg_map = hp.ud_grade(fullMap.astype(np.float64), nside_out=nsideNew, order_in='NESTED', order_out='NESTED')
+
+        # Degrade sparse map and compare to original
+        newMap = sparseMap.degrade(nside_out=nsideNew)
+
+        # Test the coverage map generation and lookup
+
+        testing.assert_almost_equal(deg_map, newMap.generateHealpixMap())
 
     def test_degradeMapRecArray(self):
         """
         Test HealSparse.degrade functionality with recarray quantities
         """
-        
+
         random.seed(seed=12345)
 
         nsideCoverage = 32
@@ -50,30 +76,35 @@ class DegradeMapTestCase(unittest.TestCase):
         ra = np.random.random(nRand) * 360.0
         dec = np.random.random(nRand) * 180.0 - 90.0
 
-        dtype = [('col1', 'f8'), ('col2', 'f8')]
+        dtype = [('col1', 'f8'), ('col2', 'f8'), ('col3', 'i4')]
         sparseMap = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, dtype, primary='col1')
         pixel = np.arange(20000)
         values = np.zeros_like(pixel, dtype=dtype)
         values['col1'] = np.random.random(size=pixel.size)
         values['col2'] = np.random.random(size=pixel.size)
+        values['col3'] = np.random.poisson(size=pixel.size, lam=2)
         sparseMap.updateValues(pixel, values)
-   
+
         # Make the test values
         hpmapCol1 = np.zeros(hp.nside2npix(nsideMap)) + hp.UNSEEN
         hpmapCol2 = np.zeros(hp.nside2npix(nsideMap)) + hp.UNSEEN
+        hpmapCol3 = np.zeros(hp.nside2npix(nsideMap)) + hp.UNSEEN
         hpmapCol1[pixel] = values['col1']
         hpmapCol2[pixel] = values['col2']
+        hpmapCol3[pixel] = values['col3']
         theta = np.radians(90.0 - dec)
         phi = np.radians(ra)
         # Degrade healpix maps
         hpmapCol1 = hp.ud_grade(hpmapCol1, nside_out=nsideNew, order_in='NESTED', order_out='NESTED')
         hpmapCol2 = hp.ud_grade(hpmapCol2, nside_out=nsideNew, order_in='NESTED', order_out='NESTED')
-        ipnestTest = hp.ang2pix(nsideNew, theta, phi, nest=True) 
+        hpmapCol3 = hp.ud_grade(hpmapCol3, nside_out=nsideNew, order_in='NESTED', order_out='NESTED')
+        ipnestTest = hp.ang2pix(nsideNew, theta, phi, nest=True)
 
         # Degrade the old map
         newSparseMap = sparseMap.degrade(nside_out=nsideNew)
         testing.assert_almost_equal(newSparseMap.getValueRaDec(ra, dec)['col1'], hpmapCol1[ipnestTest])
         testing.assert_almost_equal(newSparseMap.getValueRaDec(ra, dec)['col2'], hpmapCol2[ipnestTest])
+        testing.assert_almost_equal(newSparseMap.getValueRaDec(ra, dec)['col3'], hpmapCol3[ipnestTest])
 
 if __name__=='__main__':
     unittest.main()

--- a/tests/test_degrade.py
+++ b/tests/test_degrade.py
@@ -72,9 +72,9 @@ class DegradeMapTestCase(unittest.TestCase):
         nsideMap = 1024
         nsideNew = 256
 
-        nRand = 1000
-        ra = np.random.random(nRand) * 360.0
-        dec = np.random.random(nRand) * 180.0 - 90.0
+        #nRand = 1000
+        #ra = np.random.random(nRand) * 360.0
+        #dec = np.random.random(nRand) * 180.0 - 90.0
 
         dtype = [('col1', 'f8'), ('col2', 'f8'), ('col3', 'i4')]
         sparseMap = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, dtype, primary='col1')
@@ -85,6 +85,10 @@ class DegradeMapTestCase(unittest.TestCase):
         values['col3'] = np.random.poisson(size=pixel.size, lam=2)
         sparseMap.updateValues(pixel, values)
 
+        theta, phi = hp.pix2ang(nsideMap, pixel, nest=True)
+        ra = np.degrees(phi)
+        dec = 90.0 - np.degrees(theta)
+
         # Make the test values
         hpmapCol1 = np.zeros(hp.nside2npix(nsideMap)) + hp.UNSEEN
         hpmapCol2 = np.zeros(hp.nside2npix(nsideMap)) + hp.UNSEEN
@@ -92,8 +96,7 @@ class DegradeMapTestCase(unittest.TestCase):
         hpmapCol1[pixel] = values['col1']
         hpmapCol2[pixel] = values['col2']
         hpmapCol3[pixel] = values['col3']
-        theta = np.radians(90.0 - dec)
-        phi = np.radians(ra)
+
         # Degrade healpix maps
         hpmapCol1 = hp.ud_grade(hpmapCol1, nside_out=nsideNew, order_in='NESTED', order_out='NESTED')
         hpmapCol2 = hp.ud_grade(hpmapCol2, nside_out=nsideNew, order_in='NESTED', order_out='NESTED')

--- a/tests/test_generateHealpix.py
+++ b/tests/test_generateHealpix.py
@@ -76,5 +76,30 @@ class GenerateHealpixMapTestCase(unittest.TestCase):
         testing.assert_almost_equal(healpixMap, hp_out1)
         testing.assert_almost_equal(healpixMap2, hp_out2)
 
+    def test_generateHealpixMap_int(self):
+        """
+        Testing the generation of a healpix map from an integer map
+        """
+        random.seed(seed=12345)
+
+        nsideCoverage = 32
+        nsideMap = 64
+
+        sparseMap = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, np.int64)
+        pixel = np.arange(4000, 20000)
+        pixel = np.delete(pixel, 15000)
+        # Get a random list of integers
+        values = np.random.poisson(size=pixel.size, lam=10)
+        sparseMap.updateValues(pixel, values)
+
+        hpmap = sparseMap.generateHealpixMap()
+
+        ok, = np.where(hpmap > hp.UNSEEN)
+
+        testing.assert_almost_equal(hpmap[ok], sparseMap.getValuePixel(ok).astype(np.float64))
+
+
+
+
 if __name__=='__main__':
     unittest.main()

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -9,7 +9,7 @@ from numpy import random
 import healsparse
 
 class OperationsTestCase(unittest.TestCase):
-    def test_addition(self):
+    def test_sum(self):
         """
         Test map addition.
         """
@@ -82,16 +82,6 @@ class OperationsTestCase(unittest.TestCase):
 
         testing.assert_almost_equal(hpmapSumUnion, addedMapUnion.generateHealpixMap())
 
-        # Test adding a float constant to a map
-
-        addedMap = sparseMap1 + 2.0
-
-        hpmapAdd2 = np.zeros_like(hpmap1) + hp.UNSEEN
-        gd, = np.where(hpmap1 > hp.UNSEEN)
-        hpmapAdd2[gd] = hpmap1[gd] + 2.0
-
-        testing.assert_almost_equal(hpmapAdd2, addedMap.generateHealpixMap())
-
         # Test adding an int constant to a map
 
         addedMap = sparseMap1 + 2
@@ -102,14 +92,463 @@ class OperationsTestCase(unittest.TestCase):
 
         testing.assert_almost_equal(hpmapAdd2, addedMap.generateHealpixMap())
 
-        # Test adding a float constant to a map, in place
+        # Test adding a float constant to a map
 
-        sparseMap1 += 2.0
+        addedMap = sparseMap1 + 2.0
+
         hpmapAdd2 = np.zeros_like(hpmap1) + hp.UNSEEN
         gd, = np.where(hpmap1 > hp.UNSEEN)
         hpmapAdd2[gd] = hpmap1[gd] + 2.0
 
+        testing.assert_almost_equal(hpmapAdd2, addedMap.generateHealpixMap())
+
+        # Test adding a float constant to a map, in place
+
+        sparseMap1 += 2.0
+
         testing.assert_almost_equal(hpmapAdd2, sparseMap1.generateHealpixMap())
+
+    def test_product(self):
+        """
+        Test map products.
+        """
+
+        random.seed(seed=12345)
+
+        nsideCoverage = 32
+        nsideMap = 64
+
+        # Test adding two or three maps
+
+        sparseMap1 = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, np.float64)
+        pixel1 = np.arange(4000, 20000)
+        pixel1 = np.delete(pixel1, 15000)
+        values1 = np.random.random(size=pixel1.size)
+        sparseMap1.updateValues(pixel1, values1)
+        hpmap1 = sparseMap1.generateHealpixMap()
+
+        sparseMap2 = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, np.float64)
+        pixel2 = np.arange(15000, 25000)
+        values2 = np.random.random(size=pixel2.size)
+        sparseMap2.updateValues(pixel2, values2)
+        hpmap2 = sparseMap2.generateHealpixMap()
+
+        sparseMap3 = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, np.float64)
+        pixel3 = np.arange(16000, 25000)
+        values3 = np.random.random(size=pixel3.size)
+        sparseMap3.updateValues(pixel3, values3)
+        hpmap3 = sparseMap3.generateHealpixMap()
+
+        # Intersection product
+
+        # product of 2
+        productMapIntersection = healsparse.productIntersection([sparseMap1, sparseMap2])
+
+        gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN))
+        hpmapProductIntersection = np.zeros_like(hpmap1) + hp.UNSEEN
+        hpmapProductIntersection[gd] = hpmap1[gd] * hpmap2[gd]
+
+        testing.assert_almost_equal(hpmapProductIntersection, productMapIntersection.generateHealpixMap())
+
+        # product of 3
+        productMapIntersection = healsparse.productIntersection([sparseMap1, sparseMap2, sparseMap3])
+
+        gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN) & (hpmap3 > hp.UNSEEN))
+        hpmapProductIntersection = np.zeros_like(hpmap1) + hp.UNSEEN
+        hpmapProductIntersection[gd] = hpmap1[gd] * hpmap2[gd] * hpmap3[gd]
+
+        testing.assert_almost_equal(hpmapProductIntersection, productMapIntersection.generateHealpixMap())
+
+        # Union product
+
+        # product of 2
+        productMapUnion = healsparse.productUnion([sparseMap1, sparseMap2])
+
+        gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN))
+        hpmapProductUnion = np.zeros_like(hpmap1) + hp.UNSEEN
+
+        hpmapProductUnion[gd] = 1.0
+        gd1, = np.where(hpmap1[gd] > hp.UNSEEN)
+        hpmapProductUnion[gd[gd1]] *= hpmap1[gd[gd1]]
+        gd2, = np.where(hpmap2[gd] > hp.UNSEEN)
+        hpmapProductUnion[gd[gd2]] *= hpmap2[gd[gd2]]
+
+        testing.assert_almost_equal(hpmapProductUnion, productMapUnion.generateHealpixMap())
+
+        # product 3
+        productMapUnion = healsparse.productUnion([sparseMap1, sparseMap2, sparseMap3])
+
+        gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN) | (hpmap3 > hp.UNSEEN))
+        hpmapProductUnion = np.zeros_like(hpmap1) + hp.UNSEEN
+
+        hpmapProductUnion[gd] = 1.0
+        gd1, = np.where(hpmap1[gd] > hp.UNSEEN)
+        hpmapProductUnion[gd[gd1]] *= hpmap1[gd[gd1]]
+        gd2, = np.where(hpmap2[gd] > hp.UNSEEN)
+        hpmapProductUnion[gd[gd2]] *= hpmap2[gd[gd2]]
+        gd3, = np.where(hpmap3[gd] > hp.UNSEEN)
+        hpmapProductUnion[gd[gd3]] *= hpmap3[gd[gd3]]
+
+        testing.assert_almost_equal(hpmapProductUnion, productMapUnion.generateHealpixMap())
+
+        # Test multiplying an int constant to a map
+
+        multMap = sparseMap1 * 2
+
+        hpmapProduct2 = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where(hpmap1 > hp.UNSEEN)
+        hpmapProduct2[gd] = hpmap1[gd] * 2
+
+        testing.assert_almost_equal(hpmapProduct2, multMap.generateHealpixMap())
+
+        # Test multiplying a float constant to a map
+
+        multMap = sparseMap1 * 2.0
+
+        hpmapProduct2 = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where(hpmap1 > hp.UNSEEN)
+        hpmapProduct2[gd] = hpmap1[gd] * 2.0
+
+        testing.assert_almost_equal(hpmapProduct2, multMap.generateHealpixMap())
+
+        # Test adding a float constant to a map, in place
+
+        sparseMap1 *= 2.0
+
+        testing.assert_almost_equal(hpmapProduct2, sparseMap1.generateHealpixMap())
+
+    def test_or(self):
+        """
+        Test map bitwise or.
+        """
+
+        random.seed(seed=12345)
+
+        nsideCoverage = 32
+        nsideMap = 64
+
+        sparseMap1 = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, np.int64)
+        pixel1 = np.arange(4000, 20000)
+        pixel1 = np.delete(pixel1, 15000)
+        # Get a random list of integers
+        values1 = np.random.poisson(size=pixel1.size, lam=2)
+        sparseMap1.updateValues(pixel1, values1)
+        hpmap1 = sparseMap1.generateHealpixMap()
+
+        sparseMap2 = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, np.int64)
+        pixel2 = np.arange(15000, 25000)
+        values2 = np.random.poisson(size=pixel2.size, lam=2)
+        sparseMap2.updateValues(pixel2, values2)
+        hpmap2 = sparseMap2.generateHealpixMap()
+
+        sparseMap3 = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, np.int64)
+        pixel3 = np.arange(16000, 25000)
+        values3 = np.random.poisson(size=pixel3.size, lam=2)
+        sparseMap3.updateValues(pixel3, values3)
+        hpmap3 = sparseMap3.generateHealpixMap()
+
+        # Intersection or
+
+        # or 2
+        orMapIntersection = healsparse.orIntersection([sparseMap1, sparseMap2])
+
+        gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN))
+        hpmapOrIntersection = np.zeros_like(hpmap1) + hp.UNSEEN
+        hpmapOrIntersection[gd] = hpmap1[gd].astype(np.int64) | hpmap2[gd].astype(np.int64)
+
+        testing.assert_almost_equal(hpmapOrIntersection, orMapIntersection.generateHealpixMap())
+
+        # or 3
+        orMapIntersection = healsparse.orIntersection([sparseMap1, sparseMap2, sparseMap3])
+
+        gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN) & (hpmap3 > hp.UNSEEN))
+        hpmapOrIntersection = np.zeros_like(hpmap1) + hp.UNSEEN
+        hpmapOrIntersection[gd] = hpmap1[gd].astype(np.int64) | hpmap2[gd].astype(np.int64) | hpmap3[gd].astype(np.int64)
+
+        testing.assert_almost_equal(hpmapOrIntersection, orMapIntersection.generateHealpixMap())
+
+        # Union or
+
+        # or 2
+        orMapUnion = healsparse.orUnion([sparseMap1, sparseMap2])
+
+        gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN))
+        hpmapOrUnion = np.zeros_like(hpmap1) + hp.UNSEEN
+        hpmapOrUnion[gd] = np.clip(hpmap1[gd], 0.0, None).astype(np.int64) | np.clip(hpmap2[gd], 0.0, None).astype(np.int64)
+
+        testing.assert_almost_equal(hpmapOrUnion, orMapUnion.generateHealpixMap())
+
+        # or 3
+        orMapUnion = healsparse.orUnion([sparseMap1, sparseMap2, sparseMap3])
+
+        gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN) | (hpmap3 > hp.UNSEEN))
+        hpmapOrUnion = np.zeros_like(hpmap1) + hp.UNSEEN
+        hpmapOrUnion[gd] = np.clip(hpmap1[gd], 0.0, None).astype(np.int64) | np.clip(hpmap2[gd], 0.0, None).astype(np.int64) | np.clip(hpmap3[gd], 0.0, None).astype(np.int64)
+
+        testing.assert_almost_equal(hpmapOrUnion, orMapUnion.generateHealpixMap())
+
+        # Test orring an int constant to a map
+
+        orMap = sparseMap1 | 2
+
+        hpmapOr2 = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where(hpmap1 > hp.UNSEEN)
+        hpmapOr2[gd] = hpmap1[gd].astype(np.int64) | 2
+        testing.assert_almost_equal(hpmapOr2, orMap.generateHealpixMap())
+
+        # Test orring an int constant to a map, in place
+
+        sparseMap1 |= 2
+
+        testing.assert_almost_equal(hpmapOr2, sparseMap1.generateHealpixMap())
+
+    def test_and(self):
+        """
+        Test map bitwise and.
+        """
+
+        random.seed(seed=12345)
+
+        nsideCoverage = 32
+        nsideMap = 64
+
+        sparseMap1 = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, np.int64)
+        pixel1 = np.arange(4000, 20000)
+        pixel1 = np.delete(pixel1, 15000)
+        # Get a random list of integers
+        values1 = np.random.poisson(size=pixel1.size, lam=2)
+        sparseMap1.updateValues(pixel1, values1)
+        hpmap1 = sparseMap1.generateHealpixMap()
+
+        sparseMap2 = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, np.int64)
+        pixel2 = np.arange(15000, 25000)
+        values2 = np.random.poisson(size=pixel2.size, lam=2)
+        sparseMap2.updateValues(pixel2, values2)
+        hpmap2 = sparseMap2.generateHealpixMap()
+
+        sparseMap3 = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, np.int64)
+        pixel3 = np.arange(16000, 25000)
+        values3 = np.random.poisson(size=pixel3.size, lam=2)
+        sparseMap3.updateValues(pixel3, values3)
+        hpmap3 = sparseMap3.generateHealpixMap()
+
+        # Intersection and
+
+        # and 2
+        andMapIntersection = healsparse.andIntersection([sparseMap1, sparseMap2])
+
+        gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN))
+        hpmapAndIntersection = np.zeros_like(hpmap1) + hp.UNSEEN
+        hpmapAndIntersection[gd] = hpmap1[gd].astype(np.int64) & hpmap2[gd].astype(np.int64)
+
+        testing.assert_almost_equal(hpmapAndIntersection, andMapIntersection.generateHealpixMap())
+
+        # and 3
+        andMapIntersection = healsparse.andIntersection([sparseMap1, sparseMap2, sparseMap3])
+
+        gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN) & (hpmap3 > hp.UNSEEN))
+        hpmapAndIntersection = np.zeros_like(hpmap1) + hp.UNSEEN
+        hpmapAndIntersection[gd] = hpmap1[gd].astype(np.int64) & hpmap2[gd].astype(np.int64) & hpmap3[gd].astype(np.int64)
+
+        testing.assert_almost_equal(hpmapAndIntersection, andMapIntersection.generateHealpixMap())
+
+        # Union and
+
+        # and 2
+        andMapUnion = healsparse.andUnion([sparseMap1, sparseMap2])
+
+        gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN))
+        hpmapAndUnion = np.zeros_like(hpmap1) + hp.UNSEEN
+
+        hpmapAndUnion[gd] = -1.0
+        gd1, = np.where(hpmap1[gd] > hp.UNSEEN)
+        hpmapAndUnion[gd[gd1]] = hpmapAndUnion[gd[gd1]].astype(np.int64) & hpmap1[gd[gd1]].astype(np.int64)
+        gd2, = np.where(hpmap2[gd] > hp.UNSEEN)
+        hpmapAndUnion[gd[gd2]] = hpmapAndUnion[gd[gd2]].astype(np.int64) & hpmap2[gd[gd2]].astype(np.int64)
+
+        testing.assert_almost_equal(hpmapAndUnion, andMapUnion.generateHealpixMap())
+
+        # and 3
+        andMapUnion = healsparse.andUnion([sparseMap1, sparseMap2, sparseMap3])
+
+        gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN) | (hpmap3 > hp.UNSEEN))
+        hpmapAndUnion = np.zeros_like(hpmap1) + hp.UNSEEN
+
+        hpmapAndUnion[gd] = -1.0
+        gd1, = np.where(hpmap1[gd] > hp.UNSEEN)
+        hpmapAndUnion[gd[gd1]] = hpmapAndUnion[gd[gd1]].astype(np.int64) & hpmap1[gd[gd1]].astype(np.int64)
+        gd2, = np.where(hpmap2[gd] > hp.UNSEEN)
+        hpmapAndUnion[gd[gd2]] = hpmapAndUnion[gd[gd2]].astype(np.int64) & hpmap2[gd[gd2]].astype(np.int64)
+        gd3, = np.where(hpmap3[gd] > hp.UNSEEN)
+        hpmapAndUnion[gd[gd3]] = hpmapAndUnion[gd[gd3]].astype(np.int64) & hpmap3[gd[gd3]].astype(np.int64)
+
+        testing.assert_almost_equal(hpmapAndUnion, andMapUnion.generateHealpixMap())
+
+        # Test anding an int constant to a map
+
+        andMap = sparseMap1 & 2
+
+        hpmapAnd2 = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where(hpmap1 > hp.UNSEEN)
+        hpmapAnd2[gd] = hpmap1[gd].astype(np.int64) & 2
+        testing.assert_almost_equal(hpmapAnd2, andMap.generateHealpixMap())
+
+        # Test anding an int constant to a map, in place
+
+        sparseMap1 &= 2
+
+        testing.assert_almost_equal(hpmapAnd2, sparseMap1.generateHealpixMap())
+
+    def test_xor(self):
+        """
+        Test map bitwise xor.
+        """
+        random.seed(seed=12345)
+
+        nsideCoverage = 32
+        nsideMap = 64
+
+        sparseMap1 = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, np.int64)
+        pixel1 = np.arange(4000, 20000)
+        pixel1 = np.delete(pixel1, 15000)
+        # Get a random list of integers
+        values1 = np.random.poisson(size=pixel1.size, lam=2)
+        sparseMap1.updateValues(pixel1, values1)
+        hpmap1 = sparseMap1.generateHealpixMap()
+
+        sparseMap2 = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, np.int64)
+        pixel2 = np.arange(15000, 25000)
+        values2 = np.random.poisson(size=pixel2.size, lam=2)
+        sparseMap2.updateValues(pixel2, values2)
+        hpmap2 = sparseMap2.generateHealpixMap()
+
+        sparseMap3 = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, np.int64)
+        pixel3 = np.arange(16000, 25000)
+        values3 = np.random.poisson(size=pixel3.size, lam=2)
+        sparseMap3.updateValues(pixel3, values3)
+        hpmap3 = sparseMap3.generateHealpixMap()
+
+        # Intersection xor
+
+        # xor 2
+        xorMapIntersection = healsparse.xorIntersection([sparseMap1, sparseMap2])
+
+        gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN))
+        hpmapXorIntersection = np.zeros_like(hpmap1) + hp.UNSEEN
+        hpmapXorIntersection[gd] = hpmap1[gd].astype(np.int64) ^ hpmap2[gd].astype(np.int64)
+
+        testing.assert_almost_equal(hpmapXorIntersection, xorMapIntersection.generateHealpixMap())
+
+        # xor 3
+        xorMapIntersection = healsparse.xorIntersection([sparseMap1, sparseMap2, sparseMap3])
+
+        gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN) & (hpmap3 > hp.UNSEEN))
+        hpmapXorIntersection = np.zeros_like(hpmap1) + hp.UNSEEN
+        hpmapXorIntersection[gd] = hpmap1[gd].astype(np.int64) ^ hpmap2[gd].astype(np.int64) ^ hpmap3[gd].astype(np.int64)
+
+        testing.assert_almost_equal(hpmapXorIntersection, xorMapIntersection.generateHealpixMap())
+
+        # Union xor
+
+        # xor 2
+        xorMapUnion = healsparse.xorUnion([sparseMap1, sparseMap2])
+
+        gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN))
+        hpmapXorUnion = np.zeros_like(hpmap1) + hp.UNSEEN
+
+        hpmapXorUnion[gd] = 0.0
+        gd1, = np.where(hpmap1[gd] > hp.UNSEEN)
+        hpmapXorUnion[gd[gd1]] = hpmapXorUnion[gd[gd1]].astype(np.int64) ^ hpmap1[gd[gd1]].astype(np.int64)
+        gd2, = np.where(hpmap2[gd] > hp.UNSEEN)
+        hpmapXorUnion[gd[gd2]] = hpmapXorUnion[gd[gd2]].astype(np.int64) ^ hpmap2[gd[gd2]].astype(np.int64)
+
+        testing.assert_almost_equal(hpmapXorUnion, xorMapUnion.generateHealpixMap())
+
+        # xor 3
+        xorMapUnion = healsparse.xorUnion([sparseMap1, sparseMap2, sparseMap3])
+
+        gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN) | (hpmap3 > hp.UNSEEN))
+        hpmapXorUnion = np.zeros_like(hpmap1) + hp.UNSEEN
+
+        hpmapXorUnion[gd] = 0.0
+        gd1, = np.where(hpmap1[gd] > hp.UNSEEN)
+        hpmapXorUnion[gd[gd1]] = hpmapXorUnion[gd[gd1]].astype(np.int64) ^ hpmap1[gd[gd1]].astype(np.int64)
+        gd2, = np.where(hpmap2[gd] > hp.UNSEEN)
+        hpmapXorUnion[gd[gd2]] = hpmapXorUnion[gd[gd2]].astype(np.int64) ^ hpmap2[gd[gd2]].astype(np.int64)
+        gd3, = np.where(hpmap3[gd] > hp.UNSEEN)
+        hpmapXorUnion[gd[gd3]] = hpmapXorUnion[gd[gd3]].astype(np.int64) ^ hpmap3[gd[gd3]].astype(np.int64)
+
+        testing.assert_almost_equal(hpmapXorUnion, xorMapUnion.generateHealpixMap())
+
+        # Test xorring an int constant to a map
+
+        xorMap = sparseMap1 ^ 2
+
+        hpmapXor2 = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where(hpmap1 > hp.UNSEEN)
+        hpmapXor2[gd] = hpmap1[gd].astype(np.int64) ^ 2
+        testing.assert_almost_equal(hpmapXor2, xorMap.generateHealpixMap())
+
+        # Test xorring an int constant to a map, in place
+
+        sparseMap1 ^= 2
+
+        testing.assert_almost_equal(hpmapXor2, sparseMap1.generateHealpixMap())
+
+    def test_miscellaneous_operations(self):
+        """
+        Test miscellaneous constant operations.
+        """
+        random.seed(seed=12345)
+
+        nsideCoverage = 32
+        nsideMap = 64
+
+        sparseMap1 = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, np.float64)
+        pixel1 = np.arange(4000, 20000)
+        pixel1 = np.delete(pixel1, 15000)
+        values1 = np.random.random(size=pixel1.size)
+        sparseMap1.updateValues(pixel1, values1)
+        hpmap1 = sparseMap1.generateHealpixMap()
+
+        # subtraction
+        testMap = sparseMap1 - 2.0
+
+        hpmapTest = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where(hpmap1 > hp.UNSEEN)
+        hpmapTest[gd] = hpmap1[gd] - 2.0
+
+        testing.assert_almost_equal(hpmapTest, testMap.generateHealpixMap())
+
+        testMap = sparseMap1.copy()
+        testMap -= 2.0
+        testing.assert_almost_equal(hpmapTest, testMap.generateHealpixMap())
+
+        # division
+        testMap = sparseMap1 / 2.0
+
+        hpmapTest = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where(hpmap1 > hp.UNSEEN)
+        hpmapTest[gd] = hpmap1[gd] / 2.0
+
+        testing.assert_almost_equal(hpmapTest, testMap.generateHealpixMap())
+
+        testMap = sparseMap1.copy()
+        testMap /= 2.0
+        testing.assert_almost_equal(hpmapTest, testMap.generateHealpixMap())
+
+        # power
+        testMap = sparseMap1 ** 2.0
+
+        hpmapTest = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where(hpmap1 > hp.UNSEEN)
+        hpmapTest[gd] = hpmap1[gd] ** 2.0
+
+        testing.assert_almost_equal(hpmapTest, testMap.generateHealpixMap())
+
+        testMap = sparseMap1.copy()
+        testMap **= 2.0
+        testing.assert_almost_equal(hpmapTest, testMap.generateHealpixMap())
 
 
 if __name__=='__main__':

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -19,51 +19,97 @@ class OperationsTestCase(unittest.TestCase):
         nsideCoverage = 32
         nsideMap = 64
 
-        # Test adding two maps
+        # Test adding two or three maps
 
-        sparseMap = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, np.float64)
-        pixel = np.arange(4000, 20000)
-        values = np.random.random(size=pixel.size)
-        sparseMap.updateValues(pixel, values)
+        sparseMap1 = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, np.float64)
+        pixel1 = np.arange(4000, 20000)
+        pixel1 = np.delete(pixel1, 15000)
+        values1 = np.random.random(size=pixel1.size)
+        sparseMap1.updateValues(pixel1, values1)
+        hpmap1 = sparseMap1.generateHealpixMap()
 
         sparseMap2 = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, np.float64)
         pixel2 = np.arange(15000, 25000)
         values2 = np.random.random(size=pixel2.size)
         sparseMap2.updateValues(pixel2, values2)
-
-        addedMap = sparseMap + sparseMap2
-
-        hpmap1 = sparseMap.generateHealpixMap()
         hpmap2 = sparseMap2.generateHealpixMap()
+
+        sparseMap3 = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, np.float64)
+        pixel3 = np.arange(16000, 25000)
+        values3 = np.random.random(size=pixel3.size)
+        sparseMap3.updateValues(pixel3, values3)
+        hpmap3 = sparseMap3.generateHealpixMap()
+
+        # Intersection addition
+
+        # sum 2
+        addedMapIntersection = healsparse.sumIntersection([sparseMap1, sparseMap2])
+
         gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN))
-        hpmap3 = np.zeros_like(hpmap1) + hp.UNSEEN
-        hpmap3[gd] = hpmap1[gd] + hpmap2[gd]
+        hpmapSumIntersection = np.zeros_like(hpmap1) + hp.UNSEEN
+        hpmapSumIntersection[gd] = hpmap1[gd] + hpmap2[gd]
 
-        addedHpMap = addedMap.generateHealpixMap()
+        testing.assert_almost_equal(hpmapSumIntersection, addedMapIntersection.generateHealpixMap())
 
-        testing.assert_almost_equal(hpmap3, addedHpMap)
+        # sum 3
+        addedMapIntersection = healsparse.sumIntersection([sparseMap1, sparseMap2, sparseMap3])
+
+        gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN) & (hpmap3 > hp.UNSEEN))
+        hpmapSumIntersection = np.zeros_like(hpmap1) + hp.UNSEEN
+        hpmapSumIntersection[gd] = hpmap1[gd] + hpmap2[gd] + hpmap3[gd]
+
+        testing.assert_almost_equal(hpmapSumIntersection, addedMapIntersection.generateHealpixMap())
+
+        # Union addition
+
+        # sum 2
+        addedMapUnion = healsparse.sumUnion([sparseMap1, sparseMap2])
+
+        gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN))
+        hpmapSumUnion = np.zeros_like(hpmap1) + hp.UNSEEN
+        # This hack works because we don't have summands going below zero...
+        hpmapSumUnion[gd] = np.clip(hpmap1[gd], 0.0, None) + np.clip(hpmap2[gd], 0.0, None)
+
+        testing.assert_almost_equal(hpmapSumUnion, addedMapUnion.generateHealpixMap())
+
+        # sum 3
+        addedMapUnion = healsparse.sumUnion([sparseMap1, sparseMap2, sparseMap3])
+
+        gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN) | (hpmap3 > hp.UNSEEN))
+        hpmapSumUnion = np.zeros_like(hpmap1) + hp.UNSEEN
+        # This hack works because we don't have summands going below zero...
+        hpmapSumUnion[gd] = np.clip(hpmap1[gd], 0.0, None) + np.clip(hpmap2[gd], 0.0, None) + np.clip(hpmap3[gd], 0.0, None)
+
+        testing.assert_almost_equal(hpmapSumUnion, addedMapUnion.generateHealpixMap())
 
         # Test adding a float constant to a map
 
-        addedMap = sparseMap + 2.0
+        addedMap = sparseMap1 + 2.0
 
-        hpmap3 = np.zeros_like(hpmap1) + hp.UNSEEN
+        hpmapAdd2 = np.zeros_like(hpmap1) + hp.UNSEEN
         gd, = np.where(hpmap1 > hp.UNSEEN)
-        hpmap3[gd] = hpmap1[gd] + 2.0
+        hpmapAdd2[gd] = hpmap1[gd] + 2.0
 
-        addedHpMap = addedMap.generateHealpixMap()
-        testing.assert_almost_equal(hpmap3, addedHpMap)
+        testing.assert_almost_equal(hpmapAdd2, addedMap.generateHealpixMap())
 
         # Test adding an int constant to a map
 
-        addedMap = sparseMap + 2
+        addedMap = sparseMap1 + 2
 
-        hpmap3 = np.zeros_like(hpmap1) + hp.UNSEEN
+        hpmapAdd2 = np.zeros_like(hpmap1) + hp.UNSEEN
         gd, = np.where(hpmap1 > hp.UNSEEN)
-        hpmap3[gd] = hpmap1[gd] + 2
+        hpmapAdd2[gd] = hpmap1[gd] + 2
 
-        addedHpMap = addedMap.generateHealpixMap()
-        testing.assert_almost_equal(hpmap3, addedHpMap)
+        testing.assert_almost_equal(hpmapAdd2, addedMap.generateHealpixMap())
+
+        # Test adding a float constant to a map, in place
+
+        sparseMap1 += 2.0
+        hpmapAdd2 = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where(hpmap1 > hp.UNSEEN)
+        hpmapAdd2[gd] = hpmap1[gd] + 2.0
+
+        testing.assert_almost_equal(hpmapAdd2, sparseMap1.generateHealpixMap())
 
 
 if __name__=='__main__':

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,0 +1,72 @@
+from __future__ import division, absolute_import, print_function
+
+import unittest
+import numpy.testing as testing
+import numpy as np
+import healpy as hp
+from numpy import random
+
+import healsparse
+
+class OperationsTestCase(unittest.TestCase):
+    def test_addition(self):
+        """
+        Test map addition.
+        """
+
+        random.seed(seed=12345)
+
+        nsideCoverage = 32
+        nsideMap = 64
+
+        # Test adding two maps
+
+        sparseMap = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, np.float64)
+        pixel = np.arange(4000, 20000)
+        values = np.random.random(size=pixel.size)
+        sparseMap.updateValues(pixel, values)
+
+        sparseMap2 = healsparse.HealSparseMap.makeEmpty(nsideCoverage, nsideMap, np.float64)
+        pixel2 = np.arange(15000, 25000)
+        values2 = np.random.random(size=pixel2.size)
+        sparseMap2.updateValues(pixel2, values2)
+
+        addedMap = sparseMap + sparseMap2
+
+        hpmap1 = sparseMap.generateHealpixMap()
+        hpmap2 = sparseMap2.generateHealpixMap()
+        gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN))
+        hpmap3 = np.zeros_like(hpmap1) + hp.UNSEEN
+        hpmap3[gd] = hpmap1[gd] + hpmap2[gd]
+
+        addedHpMap = addedMap.generateHealpixMap()
+
+        testing.assert_almost_equal(hpmap3, addedHpMap)
+
+        # Test adding a float constant to a map
+
+        addedMap = sparseMap + 2.0
+
+        hpmap3 = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where(hpmap1 > hp.UNSEEN)
+        hpmap3[gd] = hpmap1[gd] + 2.0
+
+        addedHpMap = addedMap.generateHealpixMap()
+        testing.assert_almost_equal(hpmap3, addedHpMap)
+
+        # Test adding an int constant to a map
+
+        addedMap = sparseMap + 2
+
+        hpmap3 = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where(hpmap1 > hp.UNSEEN)
+        hpmap3[gd] = hpmap1[gd] + 2
+
+        addedHpMap = addedMap.generateHealpixMap()
+        testing.assert_almost_equal(hpmap3, addedHpMap)
+
+
+if __name__=='__main__':
+    unittest.main()
+
+


### PR DESCRIPTION
This PR adds operation support to HealSparseMap, and fixes a bunch of small bugs with handling of integer fields.  It also adds support for pure integer HealSparseMap with an integer equivalent to the UNSEEN value.  Single maps can be pulled out of recarray maps with simple key access.  