### PR TITLE
Add a bunch of small features that have been requested.

### DIFF
--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -1023,7 +1023,7 @@ class HealSparseMap(object):
 
             self._metadata = metadata
 
-    def generate_healpix_map(self, nside=None, reduction='mean', key=None):
+    def generate_healpix_map(self, nside=None, reduction='mean', key=None, nest=True):
         """
         Generate the associated healpix map
 
@@ -1042,6 +1042,8 @@ class HealSparseMap(object):
         key : `str`
             If the parent HealSparseMap contains recarrays, key selects the
             field that will be transformed into a HEALPix map.
+        nest : `bool`, optional
+            Output healpix map should be in nest format?
 
         Returns
         -------
@@ -1082,7 +1084,9 @@ class HealSparseMap(object):
         hp_map = np.full(hp.nside2npix(nside), hp.UNSEEN, dtype=dtypeOut)
 
         valid_pixels = single_map.valid_pixels
-        hp_map[valid_pixels] = single_map.get_values_pix(valid_pixels)
+        if not nest:
+            valid_pixels = hp.nest2ring(nside, valid_pixels)
+        hp_map[valid_pixels] = single_map.get_values_pix(valid_pixels, nest=nest)
 
         return hp_map
 

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -71,6 +71,11 @@ class HealSparseMap(object):
             # this is a healpix_map input
             if sentinel is None:
                 sentinel = hp.UNSEEN
+            if is_integer_value(healpix_map[0]) and not is_integer_value(sentinel):
+                raise ValueError("The sentinel must be set to an integer value with an integer healpix_map")
+            elif not is_integer_value(healpix_map[0]) and is_integer_value(sentinel):
+                raise ValueError("The sentinel must be set to an float value with an float healpix_map")
+
             self._cov_map, self._sparse_map = self.convert_healpix_map(healpix_map,
                                                                        nside_coverage=nside_coverage,
                                                                        nest=nest,

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -695,7 +695,7 @@ class HealSparseMap(object):
 
         self.update_values_pix(pixels, value, nest=nest, operation='and')
 
-    def get_values_pos(self, theta_or_ra, phi_or_dec, lonlat=False, valid_mask=False):
+    def get_values_pos(self, theta_or_ra, phi_or_dec, lonlat=True, valid_mask=False):
         """
         Get the map value for the position.  Positions may be theta/phi
         co-latitude and longitude in radians, or longitude and latitude in
@@ -763,7 +763,7 @@ class HealSparseMap(object):
             # Just return the values
             return values
 
-    def check_bits_pos(self, theta_or_ra, phi_or_dec, bits, lonlat=False):
+    def check_bits_pos(self, theta_or_ra, phi_or_dec, bits, lonlat=True):
         """
         Check the bits at the map for an array of positions.  Positions may be
         theta/phi co-latitude and longitude in radians, or longitude and
@@ -1099,7 +1099,7 @@ class HealSparseMap(object):
 
         return valid_pixel_inds - self._cov_map[self._cov_map.cov_pixels_from_index(valid_pixel_inds)]
 
-    def valid_pixels_pos(self, lonlat=False, return_pixels=False):
+    def valid_pixels_pos(self, lonlat=True, return_pixels=False):
         """
         Get an array with the position of valid pixels in the sparse map.
 

--- a/healsparse/utils.py
+++ b/healsparse/utils.py
@@ -67,7 +67,7 @@ def check_sentinel(type, sentinel):
         if sentinel is None:
             return hp.UNSEEN
         # If input is a float, we're okay.  Otherwise, Raise.
-        if isinstance(sentinel, numbers.Real):
+        if isinstance(sentinel, numbers.Real) and not is_integer_value(sentinel):
             return sentinel
         else:
             raise ValueError("Sentinel not of floating type")

--- a/tests/test_astype.py
+++ b/tests/test_astype.py
@@ -1,0 +1,152 @@
+import unittest
+import numpy.testing as testing
+import numpy as np
+import healpy as hp
+
+import healsparse
+
+
+class AstypeCase(unittest.TestCase):
+    def test_float_to_int(self):
+        """
+        Test float to int type conversion.
+        """
+        np.random.seed(seed=12345)
+
+        nside_coverage = 32
+        nside_map = 64
+
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, np.float64)
+        sparse_map[0: 5000] = 1.0
+        nfine_per_cov = sparse_map._cov_map.nfine_per_cov
+
+        # Convert to an int map with default sentinel
+        sparse_map_int = sparse_map.astype(np.int32)
+        self.assertEqual(sparse_map_int.dtype.type, np.dtype(np.int32).type)
+
+        testing.assert_array_equal(sparse_map.valid_pixels, sparse_map_int.valid_pixels)
+        testing.assert_array_almost_equal(sparse_map[sparse_map.valid_pixels],
+                                          sparse_map_int[sparse_map.valid_pixels])
+        testing.assert_array_equal(sparse_map_int._sparse_map[0: nfine_per_cov],
+                                   np.iinfo(np.dtype(np.int32).type).min)
+
+        # Convert to an int map with 0 sentinel
+        sparse_map_int2 = sparse_map.astype(np.int32, sentinel=0)
+
+        self.assertEqual(sparse_map_int2.dtype.type, np.dtype(np.int32).type)
+
+        testing.assert_array_equal(sparse_map.valid_pixels, sparse_map_int2.valid_pixels)
+        testing.assert_array_almost_equal(sparse_map[sparse_map.valid_pixels],
+                                          sparse_map_int2[sparse_map.valid_pixels])
+        testing.assert_array_equal(sparse_map_int2._sparse_map[0: nfine_per_cov], 0)
+
+        self.assertRaises(ValueError, sparse_map.astype, np.int32, sentinel=hp.UNSEEN)
+
+    def test_int_to_float(self):
+        """
+        Test int to float type conversion.
+        """
+        np.random.seed(seed=12345)
+
+        nside_coverage = 32
+        nside_map = 64
+
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, np.int64)
+        sparse_map[0: 5000] = 1
+        nfine_per_cov = sparse_map._cov_map.nfine_per_cov
+
+        # Convert to a float map with default sentinel
+        sparse_map_float = sparse_map.astype(np.float32)
+        self.assertEqual(sparse_map_float.dtype.type, np.dtype(np.float32).type)
+
+        testing.assert_array_equal(sparse_map.valid_pixels, sparse_map_float.valid_pixels)
+        testing.assert_array_almost_equal(sparse_map[sparse_map.valid_pixels],
+                                          sparse_map_float[sparse_map.valid_pixels])
+        testing.assert_array_equal(sparse_map_float._sparse_map[0: nfine_per_cov],
+                                   hp.UNSEEN)
+
+        # Convert to a float map with 0 sentinel
+        sparse_map_float2 = sparse_map.astype(np.float32, sentinel=0.0)
+
+        self.assertEqual(sparse_map_float2.dtype.type, np.dtype(np.float32).type)
+
+        testing.assert_array_equal(sparse_map.valid_pixels, sparse_map_float2.valid_pixels)
+        testing.assert_array_almost_equal(sparse_map[sparse_map.valid_pixels],
+                                          sparse_map_float2[sparse_map.valid_pixels])
+        testing.assert_array_equal(sparse_map_float2._sparse_map[0: nfine_per_cov], 0)
+
+        self.assertRaises(ValueError, sparse_map.astype, np.float32, sentinel=0)
+
+    def test_int_to_int(self):
+        """
+        Test int to int type conversion.
+        """
+        np.random.seed(seed=12345)
+
+        nside_coverage = 32
+        nside_map = 64
+
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, np.int64)
+        sparse_map[0: 5000] = 1
+        nfine_per_cov = sparse_map._cov_map.nfine_per_cov
+
+        # Convert to a different int map with default sentinel
+        sparse_map_int = sparse_map.astype(np.int32)
+        self.assertEqual(sparse_map_int.dtype.type, np.dtype(np.int32).type)
+
+        testing.assert_array_equal(sparse_map.valid_pixels, sparse_map_int.valid_pixels)
+        testing.assert_array_almost_equal(sparse_map[sparse_map.valid_pixels],
+                                          sparse_map_int[sparse_map.valid_pixels])
+        testing.assert_array_equal(sparse_map_int._sparse_map[0: nfine_per_cov],
+                                   np.iinfo(np.dtype(np.int32).type).min)
+
+        # Convert to a different int map with 0 sentinel
+        sparse_map_int2 = sparse_map.astype(np.int32, sentinel=0)
+
+        self.assertEqual(sparse_map_int2.dtype.type, np.dtype(np.int32).type)
+
+        testing.assert_array_equal(sparse_map.valid_pixels, sparse_map_int2.valid_pixels)
+        testing.assert_array_almost_equal(sparse_map[sparse_map.valid_pixels],
+                                          sparse_map_int2[sparse_map.valid_pixels])
+        testing.assert_array_equal(sparse_map_int2._sparse_map[0: nfine_per_cov], 0)
+
+        self.assertRaises(ValueError, sparse_map.astype, np.int32, sentinel=hp.UNSEEN)
+
+    def test_float_to_float(self):
+        """
+        Test float to float type conversion.
+        """
+        np.random.seed(seed=12345)
+
+        nside_coverage = 32
+        nside_map = 64
+
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, np.float64)
+        sparse_map[0: 5000] = 1.0
+        nfine_per_cov = sparse_map._cov_map.nfine_per_cov
+
+        # Convert to a different float map with default sentinel
+        sparse_map_float = sparse_map.astype(np.float32)
+        self.assertEqual(sparse_map_float.dtype.type, np.dtype(np.float32).type)
+
+        testing.assert_array_equal(sparse_map.valid_pixels, sparse_map_float.valid_pixels)
+        testing.assert_array_almost_equal(sparse_map[sparse_map.valid_pixels],
+                                          sparse_map_float[sparse_map.valid_pixels])
+        testing.assert_array_equal(sparse_map_float._sparse_map[0: nfine_per_cov],
+                                   hp.UNSEEN)
+
+        # Convert to a different float map with 0 sentinel
+        sparse_map_float2 = sparse_map.astype(np.float32, sentinel=0.0)
+
+        self.assertEqual(sparse_map_float2.dtype.type, np.dtype(np.float32).type)
+
+        testing.assert_array_equal(sparse_map.valid_pixels, sparse_map_float2.valid_pixels)
+        testing.assert_array_almost_equal(sparse_map[sparse_map.valid_pixels],
+                                          sparse_map_float2[sparse_map.valid_pixels])
+        testing.assert_array_equal(sparse_map_float2._sparse_map[0: nfine_per_cov], 0)
+
+        self.assertRaises(ValueError, sparse_map.astype, np.float32, sentinel=0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_from_healpix.py
+++ b/tests/test_from_healpix.py
@@ -1,0 +1,51 @@
+import unittest
+import numpy.testing as testing
+import numpy as np
+import healpy as hp
+
+import healsparse
+
+
+class GetFromHealpixCase(unittest.TestCase):
+    def test_from_healpix_float(self):
+        """
+        Test converting healpix map (float type)
+        """
+        np.random.seed(12345)
+
+        nside_coverage = 32
+        nside_map = 128
+
+        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map[0: 5000] = np.random.random(size=5000)
+
+        sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
+        testing.assert_almost_equal(full_map, sparse_map.get_values_pix(np.arange(full_map.size)))
+
+        self.assertRaises(ValueError, healsparse.HealSparseMap, healpix_map=full_map,
+                          nside_coverage=nside_coverage, sentinel=int(hp.UNSEEN))
+
+    def test_from_healpix_int(self):
+        """
+        Test converting healpix map (int type)
+        """
+        np.random.seed(12345)
+
+        nside_coverage = 32
+        nside_map = 128
+
+        full_map = np.zeros(hp.nside2npix(nside_map), dtype=np.int32) + np.iinfo(np.int32).min
+        full_map[0: 5000] = np.random.poisson(size=5000)
+
+        sparse_map = healsparse.HealSparseMap(healpix_map=full_map,
+                                              nside_coverage=nside_coverage,
+                                              sentinel=np.iinfo(np.int32).min)
+        testing.assert_array_equal(full_map,
+                                   sparse_map.get_values_pix(np.arange(full_map.size)))
+
+        self.assertRaises(ValueError, healsparse.HealSparseMap, healpix_map=full_map,
+                          nside_coverage=nside_coverage)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_generate_healpix.py
+++ b/tests/test_generate_healpix.py
@@ -99,6 +99,30 @@ class GenerateHealpixMapTestCase(unittest.TestCase):
 
         testing.assert_almost_equal(hpmap[ok], sparse_map.get_values_pix(ok).astype(np.float64))
 
+    def test_generate_healpix_map_ring(self):
+        """
+        Test the generation of a healpixmap in ring type
+        """
+        random.seed(seed=12345)
+
+        nside_coverage = 32
+        nside_map = 64
+
+        n_rand = 1000
+        ra = np.random.random(n_rand) * 360.0
+        dec = np.random.random(n_rand) * 180.0 - 90.0
+        value = np.random.random(n_rand)
+
+        # Create a HEALPix map
+        healpix_map = np.zeros(hp.nside2npix(nside_map), dtype=np.float) + hp.UNSEEN
+        idx = hp.ang2pix(nside_map, np.pi/2 - np.radians(dec), np.radians(ra), nest=True)
+        healpix_map[idx] = value
+        # Create a HealSparseMap
+        sparse_map = healsparse.HealSparseMap(nside_coverage=nside_coverage, healpix_map=healpix_map)
+        hp_out_ring = sparse_map.generate_healpix_map(nside=nside_map, nest=False)
+        healpix_map_ring = hp.reorder(healpix_map, n2r=True)
+        testing.assert_almost_equal(healpix_map_ring, hp_out_ring)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -48,7 +48,7 @@ class LookupTestCase(unittest.TestCase):
         testing.assert_almost_equal(comp_values, test_values)
 
         # Test the theta/phi lookup
-        comp_values = sparse_map.get_values_pos(theta, phi)
+        comp_values = sparse_map.get_values_pos(theta, phi, lonlat=False)
         testing.assert_almost_equal(comp_values, test_values)
 
         # Test the ra/dec lookup


### PR DESCRIPTION
- Change default from `lonlat=False` to `lonlat=True`.  This could potentially be a problem for downstream code, but I'm not sure who uses `lonlat=False` (which is I think is @kadrlica 's point).
- Add check for sentinel type when constructing from `healpix_map`.  Note that the sentinel can only be inferred for a floating point map because that is the only type that is defined for a true healpix map.
- Add option to `generate_healpix_map` to generate the map in ring format.
- Add `astype()` conversion method to convert between dtypes, properly handing the sentinel values and valid_pixels.