### PR TITLE
Add support for FITS tile compression of integer and float maps

### DIFF
--- a/docs/filespec.rst
+++ b/docs/filespec.rst
@@ -102,11 +102,20 @@ If the sparse map is a wide mask, it must contain:
 
 **Sparse Map Image**
 
-If the sparse map is not of a numpy record array type, it is stored as a one dimensional image array.  The first block of :code:`nfine_per_cov` values are set to :code:`sentinel`.  Each additional block of :code:`nfine_per_cov` is associated with a single element in the coverage map.  These blocks may be in any arbitrary order, allowing for easy appending of new coverage pixels.  All invalid pixels must be set to :code:`sentinel`.
+If the sparse map is not of a numpy record array type, it is stored as a one dimensional image array.
+The first block of :code:`nfine_per_cov` values are set to :code:`sentinel`.
+Each additional block of :code:`nfine_per_cov` is associated with a single element in the coverage map.
+These blocks may be in any arbitrary order, allowing for easy appending of new coverage pixels.
+All invalid pixels must be set to :code:`sentinel`.
+If the image is an integer type with 32 bits or fewer, it may be stored with FITS tile compression, with the tile size set to the block size (:code:`nfine_per_cov`).
+If the image is a floating-point image, it may be stored with FITS tile compression, with :code:`quantization_level=0` and :code:`GZIP_2` (lossless gzip compression), with the tile size set to the block size (:code:`nfine_per_cov`).
 
 **Sparse Map Wide Mask**
 
-If the sparse map is a wide mask map, the sparse map is stored as a flattened version of the in-memory :code:`wide_mask_width * npix` array.  This should be flattened on storage, and reshaped on read, using the default numpy memory ordering.  The sentinel value for wide masks must be :code:`0`, and all invalid pixels must be set to :code:`0`.
+If the sparse map is a wide mask map, the sparse map is stored as a flattened version of the in-memory :code:`wide_mask_width * npix` array.
+This should be flattened on storage, and reshaped on read, using the default numpy memory ordering.
+The sentinel value for wide masks must be :code:`0`, and all invalid pixels must be set to :code:`0`.
+The wide mask image may be stored with FITS tile compression, with the tile size set to the block size times with width (:code:`wide_mask_width * nfine_per_cov`).
 
 **Sparse Map Table**
 

--- a/healsparse/cat_healsparse_files.py
+++ b/healsparse/cat_healsparse_files.py
@@ -126,10 +126,13 @@ def cat_healsparse_files(file_list, outfile, check_overlap=False, clobber=False,
                                          row_range=[0, cov_map.nfine_per_cov*wmult])
         if wide_mask_maxbits is not None:
             sparse_stub = np.reshape(sparse_stub, (cov_map.nfine_per_cov, wmult))
+            # This fixes a bug in astropy<4.0
+            sparse_stub = sparse_stub.astype(WIDE_MASK)
 
     if not in_memory:
         # When spooling to disk, we need a stub to write (with the final cov_map)
-        # to append to.
+        # to append to.  The stub map cannot have compression turned on,
+        # or else appending doesn't work.
 
         stub_map = HealSparseMap(cov_map=cov_map,
                                  sparse_map=sparse_stub, nside_sparse=nside_sparse,
@@ -137,7 +140,7 @@ def cat_healsparse_files(file_list, outfile, check_overlap=False, clobber=False,
 
         # And write this out to a temporary filename
         outfile_temp = outfile + '.incomplete'
-        stub_map.write(outfile_temp, clobber=True)
+        stub_map.write(outfile_temp, clobber=True, nocompress=True)
 
         try:
             outfits = HealSparseFits(outfile_temp, mode='rw')

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -495,8 +495,10 @@ class HealSparseMap(object):
             _write_filename(filename, c_hdr, s_hdr, self._cov_map[:], self._sparse_map.ravel(),
                             compress=not nocompress,
                             compress_tilesize=self._wide_mask_width*self._cov_map.nfine_per_cov)
-        elif self.is_integer_map and self._sparse_map[0].dtype.itemsize < 8:
-            # Integer maps < 64 bit (8 byte) can be compressed.
+        elif ((self.is_integer_map and self._sparse_map[0].dtype.itemsize < 8) or
+              (not self.is_integer_map and not self._is_rec_array)):
+            # Integer maps < 64 bit (8 byte) can be compressed, as can
+            # floating point maps
             _write_filename(filename, c_hdr, s_hdr, self._cov_map[:], self._sparse_map,
                             compress=not nocompress,
                             compress_tilesize=self._cov_map.nfine_per_cov)

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -459,7 +459,7 @@ class HealSparseMap(object):
 
         return cov_map, sparse_map
 
-    def write(self, filename, clobber=False):
+    def write(self, filename, clobber=False, nocompress=False):
         """
         Write heal HealSparseMap to filename.  Use the `metadata` property from
         the map to persist additional information in the fits header.
@@ -470,6 +470,9 @@ class HealSparseMap(object):
            Name of file to save
         clobber : `bool`, optional
            Clobber existing file?  Default is False.
+        nocompress : `bool`, optional
+           If this is False, then integer maps will be compressed losslessly.
+           Note that `np.int64` maps cannot be compressed in the FITS standard.
         """
         if os.path.isfile(filename) and not clobber:
             raise RuntimeError("Filename %s exists and clobber is False." % (filename))
@@ -488,8 +491,17 @@ class HealSparseMap(object):
         if self._is_wide_mask:
             s_hdr['WIDEMASK'] = self._is_wide_mask
             s_hdr['WWIDTH'] = self._wide_mask_width
-            _write_filename(filename, c_hdr, s_hdr, self._cov_map[:], self._sparse_map.ravel())
+            # Wide masks can be compressed.
+            _write_filename(filename, c_hdr, s_hdr, self._cov_map[:], self._sparse_map.ravel(),
+                            compress=not nocompress,
+                            compress_tilesize=self._wide_mask_width*self._cov_map.nfine_per_cov)
+        elif self.is_integer_map and self._sparse_map[0].dtype.itemsize < 8:
+            # Integer maps < 64 bit (8 byte) can be compressed.
+            _write_filename(filename, c_hdr, s_hdr, self._cov_map[:], self._sparse_map,
+                            compress=not nocompress,
+                            compress_tilesize=self._cov_map.nfine_per_cov)
         else:
+            # All other maps are not compressed.
             _write_filename(filename, c_hdr, s_hdr, self._cov_map[:], self._sparse_map)
 
     def _reserve_cov_pix(self, new_cov_pix):

--- a/tests/test_fits_shim.py
+++ b/tests/test_fits_shim.py
@@ -186,10 +186,22 @@ class FitsShimTestCase(unittest.TestCase):
 
     def write_testfile(self, filename, data0, data1, header):
         """
+        Write a testfile, using astropy.io.fits only.  This is in place
+        until we get full compression support working in both.
+        """
+        _header = healsparse.fits_shim._make_header(header)
+        _header['EXTNAME'] = 'COV'
+        healsparse.fits_shim.fits.writeto(filename, data0,
+                                          header=_header)
+        _header['EXTNAME'] = 'SPARSE'
+        healsparse.fits_shim.fits.append(filename, data1,
+                                         header=_header, overwrite=False)
+
+    def write_testfile_unused(self, filename, data0, data1, header):
+        """
         Write a testfile.
         """
         if healsparse.fits_shim.use_fitsio:
-            print(filename, os.path.isfile(filename))
             healsparse.fits_shim.fitsio.write(filename, data0,
                                               header=header, extname='COV')
             healsparse.fits_shim.fitsio.write(filename, data1,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -222,6 +222,49 @@ class IoTestCase(unittest.TestCase):
         testing.assert_array_equal(valid_pixels2, pixels)
         testing.assert_array_equal(sparse_map2.get_values_pix(valid_pixels2), values)
 
+    def test_write_compression_int(self):
+        """
+        Test writing integer maps with and without compression
+        """
+        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
+
+        random.seed(seed=12345)
+
+        # We do not expect the 64-bit to be compressed, but check that it works.
+        for int_dtype in [np.int16, np.int32, np.int64]:
+            sparse_map = healsparse.HealSparseMap.make_empty(32, 4096, int_dtype)
+            sparse_map[20000: 50000] = random.poisson(lam=100, size=30000).astype(int_dtype)
+            sparse_map[120000: 150000] = -random.poisson(lam=100, size=30000).astype(int_dtype)
+
+            fname_comp = os.path.join(self.test_dir, 'test_int_map_compressed.hs')
+            sparse_map.write(fname_comp, clobber=True, nocompress=False)
+            fname_nocomp = os.path.join(self.test_dir, 'test_int_map_notcompressed.hs')
+            sparse_map.write(fname_nocomp, clobber=True, nocompress=True)
+
+            # Compare the file sizes
+            if int_dtype == np.int64:
+                self.assertEqual(os.path.getsize(fname_nocomp), os.path.getsize(fname_comp))
+            else:
+                self.assertGreater(os.path.getsize(fname_nocomp), os.path.getsize(fname_comp))
+
+            # Read in and compare
+            sparse_map_in_comp = healsparse.HealSparseMap.read(fname_comp)
+            sparse_map_in_nocomp = healsparse.HealSparseMap.read(fname_nocomp)
+
+            testing.assert_array_equal(sparse_map.valid_pixels,
+                                       sparse_map_in_nocomp.valid_pixels)
+            testing.assert_array_equal(sparse_map[sparse_map.valid_pixels],
+                                       sparse_map_in_nocomp[sparse_map.valid_pixels])
+            testing.assert_array_equal(sparse_map[0: 10],
+                                       sparse_map_in_nocomp[0: 10])
+
+            testing.assert_array_equal(sparse_map.valid_pixels,
+                                       sparse_map_in_comp.valid_pixels)
+            testing.assert_array_equal(sparse_map[sparse_map.valid_pixels],
+                                       sparse_map_in_comp[sparse_map.valid_pixels])
+            testing.assert_array_equal(sparse_map[0: 10],
+                                       sparse_map_in_comp[0: 10])
+
     def setUp(self):
         self.test_dir = None
 


### PR DESCRIPTION
This adds support for compression of integer maps.  Lossless compression of floating point images is not natively supported by the FITS standard, and thus is not possible at this time.