### PR TITLE
Issues/99

### DIFF
--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -7,6 +7,7 @@ from .healSparseCoverage import HealSparseCoverage
 from .utils import reduce_array, check_sentinel, _get_field_and_bitval, WIDE_NBIT, WIDE_MASK
 from .utils import is_integer_value, _compute_bitshift
 from .fits_shim import HealSparseFits, _make_header, _write_filename
+import warnings
 
 
 class HealSparseMap(object):
@@ -1465,41 +1466,6 @@ class HealSparseMap(object):
         else:
             return hp.pix2ang(self.nside_sparse, self.valid_pixels, lonlat=lonlat, nest=True)
 
-    def degrade(self, nside_out, reduction='mean', weights=None):
-        """
-        Method to reduce the resolution, i.e., increase the pixel size
-        of a given sparse map.
-
-        Parameters
-        ----------
-        nside_out : `int`
-           Output Nside resolution parameter.
-        reduction : `str`
-           Reduction method (mean, median, std, max, min, and, or, sum, prod, wmean).
-        weights : `healSparseMap`
-           If the reduction is `wmean` this is the map with the weights to use.
-           It should have the same characteristics as the original map.
-
-        Returns
-        -------
-        healSparseMap : `HealSparseMap`
-           New map, at the desired resolution.
-        """
-        if nside_out < self.nside_coverage:
-            # The way we do the reduction requires nside_out to be >= nside_coverage
-            # we allocate a new map with the required nside_out
-            # CAUTION: This may require a lot of memory!!
-            raise ResourceWarning("`nside_out` < `nside_coverage`. \
-                                  Allocating new map with nside_coverage=nside_out")
-            sparse_map_out = HealSparseMap.make_empty_like(self,
-                                                           nside_coverage=nside_out)
-            sparse_map_out.update_values_pix(self.valid_pixels,
-                                             self.get_values_pix(self.valid_pixels))
-            sparse_map_out = sparse_map_out._degrade(nside_out, reduction=reduction, weights=weights)
-        else:
-            sparse_map_out = self._degrade(nside_out, reduction=reduction, weights=weights)
-        return sparse_map_out
-
     def _degrade(self, nside_out, reduction='mean', weights=None):
         """
         Auxiliary method to reduce the resolution, i.e., increase the pixel size
@@ -1615,6 +1581,47 @@ class HealSparseMap(object):
                                                           self._cov_map._block_to_cov_index)
         return HealSparseMap(cov_map=new_cov_map, sparse_map=sparse_map_out,
                              nside_sparse=nside_out, primary=self._primary, sentinel=sentinel_out)
+
+    def degrade(self, nside_out, reduction='mean', weights=None):
+        """
+        Method to reduce the resolution, i.e., increase the pixel size
+        of a given sparse map.
+
+        Parameters
+        ----------
+        nside_out : `int`
+           Output Nside resolution parameter.
+        reduction : `str`
+           Reduction method (mean, median, std, max, min, and, or, sum, prod, wmean).
+        weights : `HealSparseMap`
+           If the reduction is `wmean` this is the map with the weights to use.
+           It should have the same characteristics as the original map.
+
+        Returns
+        -------
+        healSparseMap : `HealSparseMap`
+           New map, at the desired resolution.
+        """
+        if nside_out < self.nside_coverage:
+            # The way we do the reduction requires nside_out to be >= nside_coverage
+            # we allocate a new map with the required nside_out
+            # CAUTION: This may require a lot of memory!!
+            warnings.warn("`nside_out` < `nside_coverage`. \
+                            Allocating new map with nside_coverage=nside_out",
+                          ResourceWarning)
+            sparse_map_out = HealSparseMap.make_empty_like(self,
+                                                           nside_coverage=nside_out)
+            if weights is not None:
+                wgt_valid = weights.valid_pixels
+                _weights = HealSparseMap.make_empty_like(weights, nside_coverage=nside_out)
+                _weights[wgt_valid] = weights[wgt_valid]
+                weights = _weights
+            valid_pixels = self.valid_pixels
+            sparse_map_out[valid_pixels] = self[valid_pixels]
+            sparse_map_out = sparse_map_out._degrade(nside_out, reduction=reduction, weights=weights)
+        else:
+            sparse_map_out = self._degrade(nside_out, reduction=reduction, weights=weights)
+        return sparse_map_out
 
     def apply_mask(self, mask_map, mask_bits=None, mask_bit_arr=None, in_place=True):
         """

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -1467,8 +1467,43 @@ class HealSparseMap(object):
 
     def degrade(self, nside_out, reduction='mean', weights=None):
         """
-        Reduce the resolution, i.e., increase the pixel size
+        Method to reduce the resolution, i.e., increase the pixel size
         of a given sparse map.
+
+        Parameters
+        ----------
+        nside_out : `int`
+           Output Nside resolution parameter.
+        reduction : `str`
+           Reduction method (mean, median, std, max, min, and, or, sum, prod, wmean).
+        weights : `healSparseMap`
+           If the reduction is `wmean` this is the map with the weights to use.
+           It should have the same characteristics as the original map.
+
+        Returns
+        -------
+        healSparseMap : `HealSparseMap`
+           New map, at the desired resolution.
+        """
+        if nside_out < self.nside_coverage:
+            # The way we do the reduction requires nside_out to be >= nside_coverage
+            # we allocate a new map with the required nside_out
+            # CAUTION: This may require a lot of memory!!
+            raise ResourceWarning("`nside_out` < `nside_coverage`. \
+                                  Allocating new map with nside_coverage=nside_out")
+            sparse_map_out = HealSparseMap.make_empty_like(self,
+                                                           nside_coverage=nside_out)
+            sparse_map_out.update_values_pix(self.valid_pixels,
+                                             self.get_values_pix(self.valid_pixels))
+            sparse_map_out = sparse_map_out._degrade(nside_out, reduction=reduction, weights=weights)
+        else:
+            sparse_map_out = self._degrade(nside_out, reduction=reduction, weights=weights)
+        return sparse_map_out
+
+    def _degrade(self, nside_out, reduction='mean', weights=None):
+        """
+        Auxiliary method to reduce the resolution, i.e., increase the pixel size
+        of a given sparse map (which is called by `degrade`).
 
         Parameters
         ----------

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -1723,7 +1723,7 @@ class HealSparseMap(object):
         """
         Set part of a healpix map
         """
-        if isinstance(key, int):
+        if isinstance(key, numbers.Integral):
             # Set a single pixel
             return self.update_values_pix(np.array([key]), value)
         elif isinstance(key, slice):

--- a/tests/test_getset.py
+++ b/tests/test_getset.py
@@ -12,13 +12,13 @@ class GetSetTestCase(unittest.TestCase):
         """
         Test __getitem__ single value
         """
-        np.random.seed(12345)
+        random.seed(12345)
 
         nside_coverage = 32
         nside_map = 128
 
         full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
-        full_map[0: 5000] = np.random.random(size=5000)
+        full_map[0: 5000] = random.random(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
 
@@ -41,8 +41,8 @@ class GetSetTestCase(unittest.TestCase):
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, dtype, primary='col1')
         pixel = np.arange(5000)
         values = np.zeros_like(pixel, dtype=dtype)
-        values['col1'] = np.random.random(size=pixel.size)
-        values['col2'] = np.random.random(size=pixel.size)
+        values['col1'] = random.random(size=pixel.size)
+        values['col2'] = random.random(size=pixel.size)
         sparse_map.update_values_pix(pixel, values)
 
         # Test name access
@@ -63,13 +63,13 @@ class GetSetTestCase(unittest.TestCase):
         """
         Test __getitem__ using slices
         """
-        np.random.seed(12345)
+        random.seed(12345)
 
         nside_coverage = 32
         nside_map = 128
 
         full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
-        full_map[0: 5000] = np.random.random(size=5000)
+        full_map[0: 5000] = random.random(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
 
@@ -90,13 +90,13 @@ class GetSetTestCase(unittest.TestCase):
         """
         Test __getitem__ using an array
         """
-        np.random.seed(12345)
+        random.seed(12345)
 
         nside_coverage = 32
         nside_map = 128
 
         full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
-        full_map[0: 5000] = np.random.random(size=5000)
+        full_map[0: 5000] = random.random(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
 
@@ -112,13 +112,13 @@ class GetSetTestCase(unittest.TestCase):
         """
         Test __getitem__ using list/tuple
         """
-        np.random.seed(12345)
+        random.seed(12345)
 
         nside_coverage = 32
         nside_map = 128
 
         full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
-        full_map[0: 5000] = np.random.random(size=5000)
+        full_map[0: 5000] = random.random(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
 
@@ -132,13 +132,13 @@ class GetSetTestCase(unittest.TestCase):
         """
         Test __getitem__ using something else
         """
-        np.random.seed(12345)
+        random.seed(12345)
 
         nside_coverage = 32
         nside_map = 128
 
         full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
-        full_map[0: 5000] = np.random.random(size=5000)
+        full_map[0: 5000] = random.random(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
 
@@ -152,13 +152,13 @@ class GetSetTestCase(unittest.TestCase):
         """
         Test __setitem__ single value
         """
-        np.random.seed(12345)
+        random.seed(12345)
 
         nside_coverage = 32
         nside_map = 128
 
         full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
-        full_map[0: 5000] = np.random.random(size=5000)
+        full_map[0: 5000] = random.random(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
 
@@ -185,8 +185,8 @@ class GetSetTestCase(unittest.TestCase):
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, dtype, primary='col1')
         pixel = np.arange(5000)
         values = np.zeros_like(pixel, dtype=dtype)
-        values['col1'] = np.random.random(size=pixel.size)
-        values['col2'] = np.random.random(size=pixel.size)
+        values['col1'] = random.random(size=pixel.size)
+        values['col2'] = random.random(size=pixel.size)
         values['col3'] = np.ones(pixel.size, dtype=np.int32)
         sparse_map.update_values_pix(pixel, values)
 
@@ -238,13 +238,13 @@ class GetSetTestCase(unittest.TestCase):
         """
         Test __setitem__ slice
         """
-        np.random.seed(12345)
+        random.seed(12345)
 
         nside_coverage = 32
         nside_map = 128
 
         full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
-        full_map[0: 5000] = np.random.random(size=5000)
+        full_map[0: 5000] = random.random(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
 
@@ -274,13 +274,13 @@ class GetSetTestCase(unittest.TestCase):
         """
         Test __setitem__ array
         """
-        np.random.seed(12345)
+        random.seed(12345)
 
         nside_coverage = 32
         nside_map = 128
 
         full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
-        full_map[0: 5000] = np.random.random(size=5000)
+        full_map[0: 5000] = random.random(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
 
@@ -309,13 +309,13 @@ class GetSetTestCase(unittest.TestCase):
         """
         Test __setitem__ list
         """
-        np.random.seed(12345)
+        random.seed(12345)
 
         nside_coverage = 32
         nside_map = 128
 
         full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
-        full_map[0: 5000] = np.random.random(size=5000)
+        full_map[0: 5000] = random.random(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
 
@@ -338,13 +338,13 @@ class GetSetTestCase(unittest.TestCase):
         """
         Test __setitem__ using something else
         """
-        np.random.seed(12345)
+        random.seed(12345)
 
         nside_coverage = 32
         nside_map = 128
 
         full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
-        full_map[0: 5000] = np.random.random(size=5000)
+        full_map[0: 5000] = random.random(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
 
@@ -353,6 +353,26 @@ class GetSetTestCase(unittest.TestCase):
 
         indices = 5.0
         self.assertRaises(IndexError, sparse_map.__setitem__, indices, 1.0)
+
+    def test_setitem_integer(self):
+        """
+        Test __setitem__ for integer HealSparseMaps
+        """
+        random.seed(12345)
+        nside_coverage = 32
+        nside_map = 128
+        pxnums = np.arange(0, 2000)
+        pxvalues = pxnums
+        full_map = np.zeros(hp.nside2npix(nside_map), dtype=pxvalues.dtype)
+        full_map[pxnums] = pxvalues
+
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage=nside_coverage,
+                                                         nside_sparse=nside_map, dtype=pxvalues.dtype)
+        sparse_map[pxnums[0]] = pxvalues[0]
+        testing.assert_equal(sparse_map[pxnums[0]], full_map[pxnums[0]])
+
+        sparse_map[pxnums] = pxvalues
+        testing.assert_array_almost_equal(sparse_map[pxnums], full_map[pxnums])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR addresses #99 by generating a new map with lower `nside_coverage` to accomodate the requested `nside_out`. It raises a `ResourceWarning` so the user is aware that they may fill their memory pretty quickly. This also fixes another issue discovered by @erykoff for `__setitem__` using integers.