### PR TITLE
Added warning when using large nside_coverage

### DIFF
--- a/healsparse/healSparseCoverage.py
+++ b/healsparse/healSparseCoverage.py
@@ -77,7 +77,7 @@ class HealSparseCoverage(object):
            HealSparseCoverage from file
         """
         if nside_coverage >= 128:
-            warnings.warn('Using `nside_coverage` >= 128 may allocate large arrays in memory!') 
+            warnings.warn('Using `nside_coverage` >= 128 may allocate large arrays in memory!')
         bit_shift = _compute_bitshift(nside_coverage, nside_sparse)
         nfine_per_cov = 2**bit_shift
 
@@ -105,7 +105,7 @@ class HealSparseCoverage(object):
            HealSparseCoverage from file
         """
         if nside_coverage >= 128:
-            warnings.warn('Using `nside_coverage` >= 128 may allocate large arrays in memory!') 
+            warnings.warn('Using `nside_coverage` >= 128 may allocate large arrays in memory!')
         cov_map = cls.make_empty(nside_coverage, nside_sparse)
         cov_map.initialize_pixels(cov_pixels)
 

--- a/healsparse/healSparseCoverage.py
+++ b/healsparse/healSparseCoverage.py
@@ -1,5 +1,6 @@
 import numpy as np
 import healpy as hp
+import warnings
 
 from .utils import _compute_bitshift
 from .fits_shim import HealSparseFits
@@ -75,6 +76,8 @@ class HealSparseCoverage(object):
         healSparseCoverage : `HealSparseCoverage`
            HealSparseCoverage from file
         """
+        if nside_coverage >= 128:
+            warnings.warn('Using `nside_coverage` >= 128 may allocate large arrays in memory!') 
         bit_shift = _compute_bitshift(nside_coverage, nside_sparse)
         nfine_per_cov = 2**bit_shift
 
@@ -101,6 +104,8 @@ class HealSparseCoverage(object):
         healSparseCoverage : `HealSparseCoverage`
            HealSparseCoverage from file
         """
+        if nside_coverage >= 128:
+            warnings.warn('Using `nside_coverage` >= 128 may allocate large arrays in memory!') 
         cov_map = cls.make_empty(nside_coverage, nside_sparse)
         cov_map.initialize_pixels(cov_pixels)
 

--- a/healsparse/healSparseCoverage.py
+++ b/healsparse/healSparseCoverage.py
@@ -76,8 +76,8 @@ class HealSparseCoverage(object):
         healSparseCoverage : `HealSparseCoverage`
            HealSparseCoverage from file
         """
-        if nside_coverage >= 128:
-            warnings.warn('Using `nside_coverage` >= 128 may allocate large arrays in memory!')
+        if nside_coverage > 128:
+            warnings.warn('Using `nside_coverage` > 128 may result in poor performance', ResourceWarning)
         bit_shift = _compute_bitshift(nside_coverage, nside_sparse)
         nfine_per_cov = 2**bit_shift
 
@@ -104,8 +104,8 @@ class HealSparseCoverage(object):
         healSparseCoverage : `HealSparseCoverage`
            HealSparseCoverage from file
         """
-        if nside_coverage >= 128:
-            warnings.warn('Using `nside_coverage` >= 128 may allocate large arrays in memory!')
+        if nside_coverage > 128:
+            warnings.warn('Using `nside_coverage` > 128 may result in poor performance', ResourceWarning)
         cov_map = cls.make_empty(nside_coverage, nside_sparse)
         cov_map.initialize_pixels(cov_pixels)
 

--- a/tests/test_coverage_map.py
+++ b/tests/test_coverage_map.py
@@ -134,6 +134,17 @@ class CoverageMapTestCase(unittest.TestCase):
 
         return cov_map_orig
 
+    def test_large_coverage_map_warning(self):
+        """
+        Test coverage_map raises warning for large
+        values of nside_coverage
+        """
+
+        nside_coverage = 128
+        nside_map = 512
+
+        # Generate sparse map and check that it rasises a warning
+        testing.assert_warns(UserWarning, healsparse.HealSparseMap.make_empty, nside_sparse=nside_map, nside_coverage=nside_coverage, dtype=np.float32)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_coverage_map.py
+++ b/tests/test_coverage_map.py
@@ -140,11 +140,11 @@ class CoverageMapTestCase(unittest.TestCase):
         values of nside_coverage
         """
 
-        nside_coverage = 128
+        nside_coverage = 256
         nside_map = 512
 
         # Generate sparse map and check that it rasises a warning
-        testing.assert_warns(UserWarning, healsparse.HealSparseMap.make_empty, nside_sparse=nside_map,
+        testing.assert_warns(ResourceWarning, healsparse.HealSparseMap.make_empty, nside_sparse=nside_map,
                              nside_coverage=nside_coverage, dtype=np.float32)
 
 

--- a/tests/test_coverage_map.py
+++ b/tests/test_coverage_map.py
@@ -144,7 +144,9 @@ class CoverageMapTestCase(unittest.TestCase):
         nside_map = 512
 
         # Generate sparse map and check that it rasises a warning
-        testing.assert_warns(UserWarning, healsparse.HealSparseMap.make_empty, nside_sparse=nside_map, nside_coverage=nside_coverage, dtype=np.float32)
+        testing.assert_warns(UserWarning, healsparse.HealSparseMap.make_empty, nside_sparse=nside_map,
+                             nside_coverage=nside_coverage, dtype=np.float32)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR addresses #101, adding a warning with `nside_coverage >= 128` 