### PR TITLE
Add valid area method

### DIFF
--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -1531,14 +1531,14 @@ class HealSparseMap(object):
         else:
             return hp.pix2ang(self.nside_sparse, self.valid_pixels, lonlat=lonlat, nest=True)
 
-    def get_valid_area(self, degrees=False):
+    def get_valid_area(self, degrees=True):
         """
         Get the area covered by valid pixels
 
         Parameters
         ----------
-        degrees : `bool` If True returns the area in degrees,
-        if False (default) it returns the area in sterradians
+        degrees : `bool` If True (default) returns the area in square degrees,
+        if False it returns the area in steradians
 
         Returns
         -------

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -1531,6 +1531,21 @@ class HealSparseMap(object):
         else:
             return hp.pix2ang(self.nside_sparse, self.valid_pixels, lonlat=lonlat, nest=True)
 
+    def get_valid_area(self, degrees=False):
+        """
+        Get the area covered by valid pixels
+
+        Parameters
+        ----------
+        degrees : `bool` If True returns the area in degrees,
+        if False (default) it returns the area in sterradians
+
+        Returns
+        -------
+        valid_area : `float`
+        """
+        return len(self.valid_pixels)*hp.nside2pixarea(self._nside_sparse, degrees=degrees)
+
     def _degrade(self, nside_out, reduction='mean', weights=None):
         """
         Auxiliary method to reduce the resolution, i.e., increase the pixel size

--- a/tests/test_validarea.py
+++ b/tests/test_validarea.py
@@ -32,4 +32,5 @@ class ValidAreaTestCase(unittest.TestCase):
 
             # Fill up the maps
             sparse_map.update_values_pix(r_indices, np.ones(n_rand, dtype=dt))
-            testing.assert_equal(sparse_map.get_valid_area(), n_rand*hp.nside2pixarea(nside_map))
+            testing.assert_equal(sparse_map.get_valid_area(), n_rand*hp.nside2pixarea(nside_map,
+                                 degrees=True))

--- a/tests/test_validarea.py
+++ b/tests/test_validarea.py
@@ -1,0 +1,35 @@
+from __future__ import division, absolute_import, print_function
+
+import unittest
+import numpy.testing as testing
+import numpy as np
+import healpy as hp
+from numpy import random
+
+import healsparse
+
+
+class ValidAreaTestCase(unittest.TestCase):
+    def test_valid_area(self):
+        """
+        Test getting the valid area of a map
+        """
+        random.seed(seed=12345)
+
+        nside_coverage = 32
+        nside_map = 64
+
+        n_rand = 1000
+        r_indices = np.random.choice(np.arange(hp.nside2npix(nside_map)),
+                                     size=n_rand, replace=False)
+
+        for dt in [np.float64, np.int64]:
+            # Create an empty map
+            sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, dt)
+
+            # Check that the map is make_empty
+            testing.assert_equal(sparse_map.get_valid_area(), 0)
+
+            # Fill up the maps
+            sparse_map.update_values_pix(r_indices, np.ones(n_rand, dtype=dt))
+            testing.assert_equal(sparse_map.get_valid_area(), n_rand*hp.nside2pixarea(nside_map))


### PR DESCRIPTION
This issue tries to address #112, adding a method to get the "valid area" of a sparse map.