### PR TITLE
Add ability to upgrade maps as well as degrade them.

### DIFF
--- a/healsparse/healSparseCoverage.py
+++ b/healsparse/healSparseCoverage.py
@@ -270,3 +270,11 @@ class HealSparseCoverage(object):
 
     def __setitem__(self, key, value):
         self._cov_index_map[key] = value
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __str__(self):
+        descr = 'HealSparseCoverage: nside_coverage = %d, nside_sparse = %d' % (self._nside_coverage,
+                                                                                self._nside_sparse)
+        return descr

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -664,7 +664,7 @@ class HealSparseMap(object):
         """
         Get the map value for a set of pixels.
 
-        This routine will optionally convert the nside of the input pixels
+        This routine will optionally convert from a higher resolution nside
         to the nside of the sparse map.
 
         Parameters
@@ -677,6 +677,7 @@ class HealSparseMap(object):
             Return mask of True/False instead of values
         nside : `int`, optional
             nside of pixels, if different from native.
+            Must be greater than the native nside.
 
         Returns
         -------
@@ -692,12 +693,11 @@ class HealSparseMap(object):
             _pix = pixels
 
         if nside is not None:
+            if nside < self._nside_sparse:
+                raise ValueError("nside must be higher resolution than the sparse map.")
             # Convert pixels to sparse map resolution
-            bit_shift = _compute_bitshift(nside, self._nside_sparse)
-            if bit_shift < 0:
-                _pix = np.right_shift(_pix, np.abs(bit_shift))
-            else:
-                _pix = np.left_shift(_pix, bit_shift)
+            bit_shift = _compute_bitshift(self._nside_sparse, nside)
+            _pix = np.right_shift(_pix, np.abs(bit_shift))
 
         ipnest_cov = self._cov_map.cov_pixels(_pix)
 

--- a/tests/test_degrade.py
+++ b/tests/test_degrade.py
@@ -68,7 +68,7 @@ class DegradeMapTestCase(unittest.TestCase):
 
         new_map = sparse_map.degrade(nside_out=nside_new)
 
-        testing.assert_almost_equal(deg_map, new_map.generate_healpix_map())
+        testing.assert_almost_equal(new_map.generate_healpix_map(), deg_map)
 
     def test_degrade_map_int(self):
         """
@@ -125,9 +125,7 @@ class DegradeMapTestCase(unittest.TestCase):
         values['col3'] = random.poisson(size=pixel.size, lam=2)
         sparse_map.update_values_pix(pixel, values)
 
-        theta, phi = hp.pix2ang(nside_map, pixel, nest=True)
-        ra = np.degrees(phi)
-        dec = 90.0 - np.degrees(theta)
+        ra, dec = hp.pix2ang(nside_map, pixel, nest=True, lonlat=True)
 
         # Make the test values
         hpmap_col1 = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
@@ -141,7 +139,7 @@ class DegradeMapTestCase(unittest.TestCase):
         hpmap_col1 = hp.ud_grade(hpmap_col1, nside_out=nside_new, order_in='NESTED', order_out='NESTED')
         hpmap_col2 = hp.ud_grade(hpmap_col2, nside_out=nside_new, order_in='NESTED', order_out='NESTED')
         hpmap_col3 = hp.ud_grade(hpmap_col3, nside_out=nside_new, order_in='NESTED', order_out='NESTED')
-        ipnest_test = hp.ang2pix(nside_new, theta, phi, nest=True)
+        ipnest_test = hp.ang2pix(nside_new, ra, dec, nest=True, lonlat=True)
 
         # Degrade the old map
         new_map = sparse_map.degrade(nside_out=nside_new)

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -47,6 +47,17 @@ class LookupTestCase(unittest.TestCase):
         comp_values = sparse_map.get_values_pix(ipring, nest=False)
         testing.assert_almost_equal(comp_values, test_values)
 
+        # Test pixel lookup (higher nside)
+        comp_values = sparse_map.get_values_pix(
+            hp.ang2pix(4096, ra, dec, lonlat=True, nest=True),
+            nside=4096
+        )
+        testing.assert_almost_equal(comp_values, test_values)
+
+        # Test pixel lookup (lower nside)
+        lowres_pix = hp.ang2pix(256, ra, dec, lonlat=True, nest=True)
+        self.assertRaises(ValueError, sparse_map.get_values_pix, lowres_pix, nside=256)
+
         # Test the theta/phi lookup
         comp_values = sparse_map.get_values_pos(theta, phi, lonlat=False)
         testing.assert_almost_equal(comp_values, test_values)

--- a/tests/test_single_covpix.py
+++ b/tests/test_single_covpix.py
@@ -1,7 +1,6 @@
 import unittest
 import numpy.testing as testing
 import numpy as np
-import healpy as hp
 import healsparse
 from healsparse import WIDE_MASK
 

--- a/tests/test_single_covpix.py
+++ b/tests/test_single_covpix.py
@@ -1,0 +1,130 @@
+import unittest
+import numpy.testing as testing
+import numpy as np
+import healpy as hp
+import healsparse
+from healsparse import WIDE_MASK
+
+
+class SingleCovpixTestCase(unittest.TestCase):
+    def test_get_single_pixel_in_map(self):
+        """
+        Test getting a single coverage pixel map that is in the map.
+        """
+        nside_sparse = 1024
+        nside_coverage = 32
+
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage,
+                                                         nside_sparse,
+                                                         np.float32)
+        pixels = np.array([1000, 100000, 10000000])
+        sparse_map[pixels] = 1.0
+
+        cov_pixels, = np.where(sparse_map.coverage_mask)
+
+        for i, cov_pixel in enumerate(cov_pixels):
+            sub_map = sparse_map.get_single_covpix_map(cov_pixel)
+            sub_cov_pixels, = np.where(sub_map.coverage_mask)
+            self.assertEqual(len(sub_cov_pixels), 1)
+            self.assertEqual(sub_cov_pixels[0], cov_pixel)
+            self.assertEqual(sub_map.n_valid, 1)
+            testing.assert_almost_equal(sub_map[pixels[i]], 1.0)
+
+    def test_get_single_pixel_in_map_recarray(self):
+        """
+        Test getting a single coverage pixel in a recarray map.
+        """
+        nside_sparse = 1024
+        nside_coverage = 32
+        dtype = [('a', 'f4'),
+                 ('b', 'i4')]
+
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage,
+                                                         nside_sparse,
+                                                         dtype,
+                                                         primary='a')
+        pixels = np.array([1000, 100000, 10000000])
+        value = np.ones(1, dtype=dtype)
+        sparse_map[pixels] = value
+
+        cov_pixels, = np.where(sparse_map.coverage_mask)
+
+        for i, cov_pixel in enumerate(cov_pixels):
+            sub_map = sparse_map.get_single_covpix_map(cov_pixel)
+            sub_cov_pixels, = np.where(sub_map.coverage_mask)
+            self.assertEqual(len(sub_cov_pixels), 1)
+            self.assertEqual(sub_cov_pixels[0], cov_pixel)
+            self.assertEqual(sub_map.n_valid, 1)
+            testing.assert_almost_equal(sub_map[pixels[i]]['a'], 1.0)
+            self.assertEqual(sub_map[pixels[i]]['b'], 1)
+
+    def test_get_single_pixel_in_map_wide(self):
+        """
+        Test getting a single coverage pixel in a wide mask map.
+        """
+        nside_sparse = 1024
+        nside_coverage = 32
+
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage,
+                                                         nside_sparse,
+                                                         WIDE_MASK,
+                                                         wide_mask_maxbits=15)
+
+        pixels = np.array([1000, 100000, 10000000])
+        sparse_map.set_bits_pix(pixels, [4])
+        sparse_map.set_bits_pix(pixels, [13])
+
+        cov_pixels, = np.where(sparse_map.coverage_mask)
+
+        for i, cov_pixel in enumerate(cov_pixels):
+            sub_map = sparse_map.get_single_covpix_map(cov_pixel)
+            sub_cov_pixels, = np.where(sub_map.coverage_mask)
+            self.assertEqual(len(sub_cov_pixels), 1)
+            self.assertEqual(sub_cov_pixels[0], cov_pixel)
+            self.assertEqual(sub_map.n_valid, 1)
+            self.assertEqual(sub_map.check_bits_pix(pixels[i], [4]), True)
+            self.assertEqual(sub_map.check_bits_pix(pixels[i], [13]), True)
+
+    def test_get_single_pixel_not_in_map(self):
+        """
+        Test getting a single coverage pixel map that is not in the map.
+        """
+        nside_sparse = 1024
+        nside_coverage = 32
+
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage,
+                                                         nside_sparse,
+                                                         np.float32)
+        pixels = np.array([1000, 100000, 10000000])
+        sparse_map[pixels] = 1.0
+
+        sub_map = sparse_map.get_single_covpix_map(40)
+        sub_cov_pixels, = np.where(sub_map.coverage_mask)
+        self.assertEqual(len(sub_cov_pixels), 0)
+        self.assertEqual(sub_map.n_valid, 0)
+
+    def test_single_pixel_generator(self):
+        """
+        Test iterating over all of the single coverage pixel maps.
+        """
+        nside_sparse = 1024
+        nside_coverage = 32
+
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage,
+                                                         nside_sparse,
+                                                         np.float32)
+        pixels = np.array([1000, 100000, 10000000])
+        sparse_map[pixels] = 1.0
+
+        cov_pixels, = np.where(sparse_map.coverage_mask)
+
+        for i, sub_map in enumerate(sparse_map.get_covpix_maps()):
+            sub_cov_pixels, = np.where(sub_map.coverage_mask)
+            self.assertEqual(len(sub_cov_pixels), 1)
+            self.assertEqual(sub_cov_pixels[0], cov_pixels[i])
+            self.assertEqual(sub_map.n_valid, 1)
+            testing.assert_almost_equal(sub_map[pixels[i]], 1.0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -23,7 +23,7 @@ class UpgradeMapTestCase(unittest.TestCase):
         # Upgrade original map
         upg_map = hp.ud_grade(full_map, nside_out=nside_new, order_in='NESTED', order_out='NESTED')
         # Upgrade sparse map and compare
-        new_map = sparse_map.degrade(nside_out=nside_new)
+        new_map = sparse_map.upgrade(nside_out=nside_new)
 
         testing.assert_almost_equal(upg_map, new_map.generate_healpix_map())
 
@@ -44,7 +44,7 @@ class UpgradeMapTestCase(unittest.TestCase):
 
         deg_map = hp.ud_grade(full_map, nside_out=nside_new, order_in='NESTED', order_out='NESTED')
 
-        new_map = sparse_map.degrade(nside_out=nside_new)
+        new_map = sparse_map.upgrade(nside_out=nside_new)
 
         testing.assert_almost_equal(new_map.generate_healpix_map(), deg_map)
 
@@ -77,14 +77,14 @@ class UpgradeMapTestCase(unittest.TestCase):
         hpmap_col2[pixel] = values['col2']
         hpmap_col3[pixel] = values['col3']
 
-        # Degrade healpix maps
+        # Upgrade healpix maps
         hpmap_col1 = hp.ud_grade(hpmap_col1, nside_out=nside_new, order_in='NESTED', order_out='NESTED')
         hpmap_col2 = hp.ud_grade(hpmap_col2, nside_out=nside_new, order_in='NESTED', order_out='NESTED')
         hpmap_col3 = hp.ud_grade(hpmap_col3, nside_out=nside_new, order_in='NESTED', order_out='NESTED')
         ipnest_test = hp.ang2pix(nside_new, ra, dec, nest=True, lonlat=True)
 
         # Upgrade the old map
-        new_map = sparse_map.degrade(nside_out=nside_new)
+        new_map = sparse_map.upgrade(nside_out=nside_new)
         testing.assert_almost_equal(new_map.get_values_pos(ra, dec, lonlat=True)['col1'],
                                     hpmap_col1[ipnest_test])
         testing.assert_almost_equal(new_map.get_values_pos(ra, dec, lonlat=True)['col2'],
@@ -102,7 +102,7 @@ class UpgradeMapTestCase(unittest.TestCase):
         nside_map2 = 256
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map,
                                                          healsparse.WIDE_MASK, wide_mask_maxbits=7)
-        self.assertRaises(NotImplementedError, sparse_map.degrade, nside_map2)
+        self.assertRaises(NotImplementedError, sparse_map.upgrade, nside_map2)
 
 
 if __name__ == '__main__':

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,0 +1,110 @@
+import unittest
+import numpy.testing as testing
+import numpy as np
+import healpy as hp
+from numpy import random
+import healsparse
+
+
+class UpgradeMapTestCase(unittest.TestCase):
+    def test_upgrade_map(self):
+        """
+        Test upgrade functionality with regular map.
+        """
+        random.seed(12345)
+        nside_coverage = 32
+        nside_map = 256
+        nside_new = 1024
+        full_map = random.random(hp.nside2npix(nside_map))
+
+        # Generate sparse map
+        sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage,
+                                              nside_sparse=nside_map)
+        # Upgrade original map
+        upg_map = hp.ud_grade(full_map, nside_out=nside_new, order_in='NESTED', order_out='NESTED')
+        # Upgrade sparse map and compare
+        new_map = sparse_map.degrade(nside_out=nside_new)
+
+        testing.assert_almost_equal(upg_map, new_map.generate_healpix_map())
+
+    def test_upgrade_map_outoforder(self):
+        """
+        Test upgrade functionality with an out-of-order map.
+        """
+        nside_coverage = 32
+        nside_map = 256
+        nside_new = 1024
+
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map,
+                                                         np.float32)
+        sparse_map[100000: 110000] = 1.0
+        sparse_map[10000: 20000] = 2.0
+
+        full_map = sparse_map.generate_healpix_map()
+
+        deg_map = hp.ud_grade(full_map, nside_out=nside_new, order_in='NESTED', order_out='NESTED')
+
+        new_map = sparse_map.degrade(nside_out=nside_new)
+
+        testing.assert_almost_equal(new_map.generate_healpix_map(), deg_map)
+
+    def test_upgrade_map_recarray(self):
+        """
+        Test upgrade functionality with a recarray.
+        """
+        random.seed(seed=12345)
+
+        nside_coverage = 32
+        nside_map = 256
+        nside_new = 1024
+
+        dtype = [('col1', 'f8'), ('col2', 'f8'), ('col3', 'i4')]
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, dtype, primary='col1')
+        pixel = np.arange(20000)
+        values = np.zeros_like(pixel, dtype=dtype)
+        values['col1'] = random.random(size=pixel.size)
+        values['col2'] = random.random(size=pixel.size)
+        values['col3'] = random.poisson(size=pixel.size, lam=2)
+        sparse_map.update_values_pix(pixel, values)
+
+        ra, dec = hp.pix2ang(nside_map, pixel, nest=True, lonlat=True)
+
+        # Make the test values
+        hpmap_col1 = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        hpmap_col2 = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        hpmap_col3 = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        hpmap_col1[pixel] = values['col1']
+        hpmap_col2[pixel] = values['col2']
+        hpmap_col3[pixel] = values['col3']
+
+        # Degrade healpix maps
+        hpmap_col1 = hp.ud_grade(hpmap_col1, nside_out=nside_new, order_in='NESTED', order_out='NESTED')
+        hpmap_col2 = hp.ud_grade(hpmap_col2, nside_out=nside_new, order_in='NESTED', order_out='NESTED')
+        hpmap_col3 = hp.ud_grade(hpmap_col3, nside_out=nside_new, order_in='NESTED', order_out='NESTED')
+        ipnest_test = hp.ang2pix(nside_new, ra, dec, nest=True, lonlat=True)
+
+        # Upgrade the old map
+        new_map = sparse_map.degrade(nside_out=nside_new)
+        testing.assert_almost_equal(new_map.get_values_pos(ra, dec, lonlat=True)['col1'],
+                                    hpmap_col1[ipnest_test])
+        testing.assert_almost_equal(new_map.get_values_pos(ra, dec, lonlat=True)['col2'],
+                                    hpmap_col2[ipnest_test])
+        testing.assert_almost_equal(new_map.get_values_pos(ra, dec, lonlat=True)['col3'],
+                                    hpmap_col3[ipnest_test])
+
+    def test_upgrade_map_widemask(self):
+        """
+        Test upgrade functionality with a wide mask.
+        (not implemented)
+        """
+        nside_coverage = 32
+        nside_map = 64
+        nside_map2 = 256
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map,
+                                                         healsparse.WIDE_MASK, wide_mask_maxbits=7)
+        self.assertRaises(NotImplementedError, sparse_map.degrade, nside_map2)
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -107,4 +107,3 @@ class UpgradeMapTestCase(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
This PR also adds the ability to get values out of a map using higher nside pixels (for convenience), as well as the ability to get a copy of the map from a single coverage pixel, and an easy way of iterating over all coverage pixels.  For large high-res maps this functionality will allow downstream code to have less memory overhead.