### PR TITLE
Add support for boolean-valued maps.

### DIFF
--- a/healsparse/fits_shim.py
+++ b/healsparse/fits_shim.py
@@ -132,9 +132,9 @@ class HealSparseFits(object):
         else:
             hdu = self.fits_object[extension]
             if row_range is None:
-                return hdu.data.view(np.ndarray, memmap=False)
+                return hdu.data.view(np.ndarray)
             else:
-                return hdu.data[slice(row_range[0], row_range[1])].view(np.ndarray, memmap=False)
+                return hdu.data[slice(row_range[0], row_range[1])].view(np.ndarray)
 
     def ext_is_image(self, extension):
         """

--- a/healsparse/fits_shim.py
+++ b/healsparse/fits_shim.py
@@ -132,9 +132,9 @@ class HealSparseFits(object):
         else:
             hdu = self.fits_object[extension]
             if row_range is None:
-                return hdu.data.view(np.ndarray)
+                return hdu.data.view(np.ndarray, memmap=False)
             else:
-                return hdu.data[slice(row_range[0], row_range[1])].view(np.ndarray)
+                return hdu.data[slice(row_range[0], row_range[1])].view(np.ndarray, memmap=False)
 
     def ext_is_image(self, extension):
         """

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -467,7 +467,7 @@ class HealSparseMap(object):
             else:
                 # Non wide_mask
                 if isinstance(values, numbers.Integral):
-                    if not self.is_integer_map:
+                    if not self.is_integer_map and self.dtype.type is not np.bool_:
                         raise ValueError("Cannot set non-integer map with an integer")
                     is_single_value = True
                     _values = np.array([values], dtype=self.dtype)

--- a/healsparse/io_map_fits.py
+++ b/healsparse/io_map_fits.py
@@ -472,14 +472,7 @@ def _write_map_fits(hsp_map, filename, clobber=False, nocompress=False):
                         compress=not nocompress,
                         compress_tilesize=hsp_map._wide_mask_width*hsp_map._cov_map.nfine_per_cov)
     elif is_boolean:
-        # Boolean maps need to be converted to a small integer and can be compressed.
-        # Some versions of astropy can't use int8 so try and then do int16
-        # try:
-        #     _write_filename(filename, c_hdr, s_hdr, hsp_map._cov_map[:],
-        #                     hsp_map._sparse_map.astype(np.int8),
-        #                     compress=not nocompress,
-        #                     compress_tilesize=hsp_map._cov_map.nfine_per_cov)
-        # except KeyError:
+        # Fits support for 16 bit integers is much better than 8 bit.
         _write_filename(filename, c_hdr, s_hdr, hsp_map._cov_map[:],
                         hsp_map._sparse_map.astype(np.int16),
                         compress=not nocompress,

--- a/healsparse/io_map_fits.py
+++ b/healsparse/io_map_fits.py
@@ -474,7 +474,7 @@ def _write_map_fits(hsp_map, filename, clobber=False, nocompress=False):
     elif is_boolean:
         # Fits support for 16 bit integers is much better than 8 bit.
         _write_filename(filename, c_hdr, s_hdr, hsp_map._cov_map[:],
-                        hsp_map._sparse_map.astype(np.int16),
+                        hsp_map._sparse_map.astype(np.uint8),
                         compress=not nocompress,
                         compress_tilesize=hsp_map._cov_map.nfine_per_cov)
     elif ((hsp_map.is_integer_map and hsp_map._sparse_map[0].dtype.itemsize < 8) or

--- a/healsparse/io_map_fits.py
+++ b/healsparse/io_map_fits.py
@@ -451,12 +451,6 @@ def _write_map_fits(hsp_map, filename, clobber=False, nocompress=False):
     if os.path.isfile(filename) and not clobber:
         raise RuntimeError("Filename %s exists and clobber is False." % (filename))
 
-    """
-    if hsp_map.dtype.type is np.bool_:
-        raise RuntimeError("Boolean maps must be converted to ``numpy.int8`` "
-                           "(astropy>=5) or ``numpy.int16`` (astropy<5) "
-                           "prior to serialization with FITS.")
-    """
     # Note that we put the requested header information in each of the extensions.
     c_hdr = _make_header(hsp_map.metadata)
     c_hdr['PIXTYPE'] = 'HEALSPARSE'
@@ -480,16 +474,16 @@ def _write_map_fits(hsp_map, filename, clobber=False, nocompress=False):
     elif is_boolean:
         # Boolean maps need to be converted to a small integer and can be compressed.
         # Some versions of astropy can't use int8 so try and then do int16
-        try:
-            _write_filename(filename, c_hdr, s_hdr, hsp_map._cov_map[:],
-                            hsp_map._sparse_map.astype(np.int8),
-                            compress=not nocompress,
-                            compress_tilesize=hsp_map._cov_map.nfine_per_cov)
-        except KeyError:
-            _write_filename(filename, c_hdr, s_hdr, hsp_map._cov_map[:],
-                            hsp_map._sparse_map.astype(np.int16),
-                            compress=not nocompress,
-                            compress_tilesize=hsp_map._cov_map.nfine_per_cov)
+        # try:
+        #     _write_filename(filename, c_hdr, s_hdr, hsp_map._cov_map[:],
+        #                     hsp_map._sparse_map.astype(np.int8),
+        #                     compress=not nocompress,
+        #                     compress_tilesize=hsp_map._cov_map.nfine_per_cov)
+        # except KeyError:
+        _write_filename(filename, c_hdr, s_hdr, hsp_map._cov_map[:],
+                        hsp_map._sparse_map.astype(np.int16),
+                        compress=not nocompress,
+                        compress_tilesize=hsp_map._cov_map.nfine_per_cov)
     elif ((hsp_map.is_integer_map and hsp_map._sparse_map[0].dtype.itemsize < 8) or
           (not hsp_map.is_integer_map and not hsp_map._is_rec_array)):
         # Integer maps < 64 bit (8 byte) can be compressed, as can

--- a/healsparse/io_map_fits.py
+++ b/healsparse/io_map_fits.py
@@ -445,6 +445,9 @@ def _write_map_fits(hsp_map, filename, clobber=False, nocompress=False):
     if os.path.isfile(filename) and not clobber:
         raise RuntimeError("Filename %s exists and clobber is False." % (filename))
 
+    if hsp_map.dtype.type is np.bool_:
+        raise RuntimeError("Boolean maps cannot be serialized with FITS.")
+
     # Note that we put the requested header information in each of the extensions.
     c_hdr = _make_header(hsp_map.metadata)
     c_hdr['PIXTYPE'] = 'HEALSPARSE'

--- a/healsparse/io_map_fits.py
+++ b/healsparse/io_map_fits.py
@@ -472,7 +472,7 @@ def _write_map_fits(hsp_map, filename, clobber=False, nocompress=False):
                         compress=not nocompress,
                         compress_tilesize=hsp_map._wide_mask_width*hsp_map._cov_map.nfine_per_cov)
     elif is_boolean:
-        # Fits support for 16 bit integers is much better than 8 bit.
+        # We have to store the booleans as uint8 for fits compatibility.
         _write_filename(filename, c_hdr, s_hdr, hsp_map._cov_map[:],
                         hsp_map._sparse_map.astype(np.uint8),
                         compress=not nocompress,

--- a/healsparse/io_map_fits.py
+++ b/healsparse/io_map_fits.py
@@ -446,7 +446,9 @@ def _write_map_fits(hsp_map, filename, clobber=False, nocompress=False):
         raise RuntimeError("Filename %s exists and clobber is False." % (filename))
 
     if hsp_map.dtype.type is np.bool_:
-        raise RuntimeError("Boolean maps cannot be serialized with FITS.")
+        raise RuntimeError("Boolean maps must be converted to ``numpy.int8`` "
+                           "(astropy>=5) or ``numpy.int16`` (astropy<5) "
+                           "prior to serialization with FITS.")
 
     # Note that we put the requested header information in each of the extensions.
     c_hdr = _make_header(hsp_map.metadata)

--- a/healsparse/io_map_parquet.py
+++ b/healsparse/io_map_parquet.py
@@ -128,6 +128,10 @@ def _read_map_parquet(healsparse_class, filepath, pixels=None, header=False,
 
     if md['healsparse::sentinel'] == 'UNSEEN':
         sentinel = primary_dtype(hp.UNSEEN)
+    elif md['healsparse::sentinel'] == 'True':
+        sentinel = True
+    elif md['healsparse::sentinel'] == 'False':
+        sentinel = False
     else:
         sentinel = primary_dtype(md['healsparse::sentinel'])
 

--- a/healsparse/utils.py
+++ b/healsparse/utils.py
@@ -103,6 +103,14 @@ def check_sentinel(type, sentinel):
             return sentinel
         else:
             raise ValueError("Sentinel not of integer type")
+    elif issubclass(type, np.bool_):
+        if sentinel is None:
+            return False
+        if sentinel is not True and sentinel is not False:
+            raise ValueError("Sentinel not of boolean type")
+        return sentinel
+    else:
+        raise RuntimeError("Unsupported data type; must be integer, floating, or boolean.")
 
 
 def is_integer_value(value):

--- a/tests/test_buildmaps.py
+++ b/tests/test_buildmaps.py
@@ -179,6 +179,25 @@ class BuildMapsTestCase(unittest.TestCase):
         testing.assert_array_equal(sparse_map2b._sparse_map['col1'], sparse_map._sentinel)
         testing.assert_array_equal(sparse_map2b._sparse_map['col2'], hp.UNSEEN)
 
+    def test_buildmaps_boolean(self):
+        """
+        Test building a boolean map
+        """
+        nside_coverage = 32
+        nside_map = 64
+
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, np.bool_)
+        pixel = np.arange(4000, 20000)
+        values = np.ones(pixel.size, dtype=np.bool_)
+        sparse_map[pixel] = values
+
+        testing.assert_array_equal(sparse_map[pixel], values)
+        self.assertEqual(sparse_map.n_valid, pixel.size)
+
+        # Test reset with single value
+        sparse_map[pixel] = False
+        self.assertEqual(sparse_map.n_valid, 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -323,18 +323,19 @@ class FitsIoTestCase(unittest.TestCase):
         sparse_map[20000: 50000] = True
 
         fname_comp = os.path.join(self.test_dir, 'test_bool_map_compressed.hsp')
-
-        self.assertRaises(RuntimeError, sparse_map.write, fname_comp)
-
-        sparse_map2 = sparse_map.astype(np.int16)
-        sparse_map2.write(fname_comp, clobber=True, nocompress=False)
+        sparse_map.write(fname_comp, clobber=True, nocompress=False)
         fname_nocomp = os.path.join(self.test_dir, 'test_bool_map_notcompressed.hsp')
-        sparse_map2.write(fname_nocomp, clobber=True, nocompress=True)
+        sparse_map.write(fname_nocomp, clobber=True, nocompress=True)
 
         self.assertGreater(os.path.getsize(fname_nocomp), os.path.getsize(fname_comp))
 
-        sparse_map_in_comp = healsparse.HealSparseMap.read(fname_comp).astype(np.bool_)
-        sparse_map_in_nocomp = healsparse.HealSparseMap.read(fname_nocomp).astype(np.bool_)
+        sparse_map_in_comp = healsparse.HealSparseMap.read(fname_comp)
+        sparse_map_in_nocomp = healsparse.HealSparseMap.read(fname_nocomp)
+
+        self.assertEqual(sparse_map_in_comp.dtype, np.bool_)
+        self.assertEqual(sparse_map_in_nocomp.dtype, np.bool_)
+        self.assertTrue(isinstance(sparse_map_in_comp._sentinel, bool))
+        self.assertTrue(isinstance(sparse_map_in_nocomp._sentinel, bool))
 
         testing.assert_array_equal(sparse_map_in_comp.valid_pixels, sparse_map.valid_pixels)
         testing.assert_array_equal(sparse_map_in_nocomp.valid_pixels, sparse_map.valid_pixels)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -311,6 +311,21 @@ class FitsIoTestCase(unittest.TestCase):
             testing.assert_array_almost_equal(sparse_map[0: 10],
                                               sparse_map_in_comp[0: 10])
 
+    def test_fits_write_boolean(self):
+        """
+        Test fits writing boolean maps (which is not supported).
+        """
+        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
+
+        random.seed(seed=12345)
+
+        sparse_map = healsparse.HealSparseMap.make_empty(32, 4096, np.bool_)
+        sparse_map[20000: 50000] = True
+
+        fname = os.path.join(self.test_dir, 'test_bool_map.hsp')
+
+        self.assertRaises(RuntimeError, sparse_map.write, fname)
+
     def setUp(self):
         self.test_dir = None
 

--- a/tests/test_io_parquet.py
+++ b/tests/test_io_parquet.py
@@ -237,6 +237,25 @@ class ParquetIoTestCase(unittest.TestCase):
         self.assertRaises(ValueError, sparse_map2.write, fname,
                           format='parquet', nside_io=32)
 
+    def test_parquet_write_boolean(self):
+        """
+        Test parquet writing boolean maps.
+        """
+        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
+
+        sparse_map = healsparse.HealSparseMap.make_empty(32, 4096, np.bool_)
+        sparse_map[20000: 50000] = True
+
+        fname = os.path.join(self.test_dir, 'healsparse_map.hsparquet')
+
+        sparse_map.write(fname, format='parquet')
+
+        sparse_map_in = healsparse.HealSparseMap.read(fname)
+
+        testing.assert_array_equal(sparse_map_in.valid_pixels, sparse_map.valid_pixels)
+        testing.assert_array_equal(sparse_map_in[sparse_map_in.valid_pixels],
+                                   sparse_map[sparse_map.valid_pixels])
+
     def setUp(self):
         self.test_dir = None
 


### PR DESCRIPTION
Note that these can only be serialized with parquet and not fits.