### PR TITLE
Add native support for reading/writing explicit/partial healpix maps.

### DIFF
--- a/healsparse/fits_shim.py
+++ b/healsparse/fits_shim.py
@@ -299,3 +299,31 @@ def _make_header(metadata):
         hdr = fits.Header(metadata)
 
     return hdr
+
+
+def _write_healpix_filename(filename, hdr, output_struct):
+    """
+    Write to a filename, HEALPix EXPLICIT format, using astropy.io.fits.
+
+    This assumes that you want to overwrite any existing file (as should be
+    checked in the calling function.)
+
+    Parameters
+    ----------
+    filename : `str`
+        Name of file to write to.
+    hdr : `astropy.io.fits.Header`
+        Correctly formatted header.
+    output_struct : `numpy.recarray`
+        Correctly formatted output struct.
+    """
+    hdu_list = fits.HDUList()
+
+    hdu = fits.BinTableHDU(data=output_struct, header=fits.Header())
+
+    for n in hdr:
+        if n not in FITS_RESERVED:
+            hdu.header[n] = hdr[n]
+    hdu_list.append(hdu)
+
+    hdu_list.writeto(filename, overwrite=True)

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -346,13 +346,15 @@ class HealSparseMap(object):
         nocompress : `bool`, optional
             If this is False, then integer maps will be compressed losslessly.
             Note that `np.int64` maps cannot be compressed in the FITS standard.
-            This option only applies if format='fits'.
+            This option only applies if format=``fits``.
         nside_io : `int`, optional
             The healpix nside to partition the output map files in parquet.
             Must be less than or equal to nside_coverage, and not greater than 16.
-            This option only applies if format='parquet'.
+            This option only applies if format=``parquet``.
         format : `str`, optional
-            File format.  Currently only 'fits' is supported.
+            File format.  May be ``fits``, ``parquet``, or ``healpix``. Note that
+            the ``healpix`` EXPLICIT format does not maintain all metadata and
+            coverage information.
 
         Raises
         ------

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -1229,7 +1229,8 @@ class HealSparseMap(object):
         weight_values = None
         if weights is not None:
             if reduction != 'wmean':
-                raise Warning('Weights only used with wmean reduction.  Ignoring weights.')
+                warnings.warn('Weights only used with wmean reduction.  Ignoring weights.',
+                              UserWarning)
             else:
                 # Check format/size of weight-map here.
                 if not isinstance(weights, HealSparseMap):

--- a/healsparse/io_map.py
+++ b/healsparse/io_map.py
@@ -4,6 +4,7 @@ from .fits_shim import HealSparseFits
 from .io_map_fits import _read_map_fits, _write_map_fits
 from .parquet_shim import check_parquet_dataset
 from .io_map_parquet import _read_map_parquet, _write_map_parquet
+from .io_map_healpix import _write_map_healpix
 
 
 def _read_map(healsparse_class, filename, nside_coverage=None, pixels=None, header=False,
@@ -89,13 +90,13 @@ def _write_map(hsp_map, filename, clobber=False, nocompress=False, format='fits'
     nocompress : `bool`, optional
         If this is False, then integer maps will be compressed losslessly.
         Note that `np.int64` maps cannot be compressed in the FITS standard.
-        This option only applies if format='fits'.
+        This option only applies if format=``fits``.
     nside_io : `int`, optional
         The healpix nside to partition the output map files in parquet.
-        This option only applies if format='parquet'.
+        This option only applies if format=``parquet``.
         Must be less than or equal to nside_coverage, and not greater than 16.
     format : `str`, optional
-        File format.  May be 'fits' or 'parquet'.
+        File format.  May be ``fits``, ``parquet``, or ``healpix``.
 
     Raises
     ------
@@ -106,5 +107,7 @@ def _write_map(hsp_map, filename, clobber=False, nocompress=False, format='fits'
         _write_map_fits(hsp_map, filename, clobber=clobber, nocompress=nocompress)
     elif format == 'parquet':
         _write_map_parquet(hsp_map, filename, clobber=clobber, nside_io=nside_io)
+    elif format == 'healpix':
+        _write_map_healpix(hsp_map, filename, clobber=clobber)
     else:
-        raise NotImplementedError("Only 'fits' and 'parquet' file formats are supported.")
+        raise NotImplementedError("Only 'fits', 'parquet' and 'healpix' file formats are supported.")

--- a/healsparse/io_map_healpix.py
+++ b/healsparse/io_map_healpix.py
@@ -1,0 +1,56 @@
+import os
+import numpy as np
+import warnings
+
+from .fits_shim import _make_header, _write_healpix_filename
+
+
+def _write_map_healpix(hsp_map, filename, clobber=False):
+    """
+    Internal method to write a HealSparseMap with healpix EXPLICIT format.
+
+    Note that the coverage map is not persisted in this format, and only
+    floating point value maps are supported.
+
+    Parameters
+    ----------
+    hsp_map : `HealSparseMap`
+        HealSparseMap to write to a file.
+    filename : `str`
+        Name of file to save
+    clobber : `bool`, optional
+        Clobber existing file?  Default is False.
+
+    Raises
+    ------
+    RuntimeError if file exists and clobber is False.
+    NotImplementedError if persisting anything other than a floating point map.
+    """
+
+    if hsp_map.is_rec_array:
+        raise NotImplementedError("The healpix EXPLICIT output format is not supported for recarray maps.")
+
+    if hsp_map.is_integer_map:
+        warnings.warn("Integer maps will be converted to float on read by healpy.", UserWarning)
+
+    if os.path.isfile(filename) and not clobber:
+        raise RuntimeError("Filename %s exists and clobber is False." % (filename))
+
+    valid_pixels = hsp_map.valid_pixels
+
+    hdr = _make_header(hsp_map.metadata)
+    hdr['PIXTYPE'] = 'HEALPIX'
+    hdr['INDXSCHM'] = 'EXPLICIT'
+    hdr['ORDERING'] = 'NESTED'
+    hdr['NSIDE'] = hsp_map._nside_sparse
+    hdr['OBS_NPIX'] = valid_pixels.size
+    hdr['BAD_DATA'] = hsp_map._sentinel
+    hdr['OBJECT'] = 'PARTIAL'
+    hdr['COORDSYS'] = 'C'
+
+    output_struct = np.zeros(valid_pixels.size, dtype=[('PIXEL', 'i8'),
+                                                       ('SIGNAL', hsp_map.dtype)])
+    output_struct['PIXEL'][:] = valid_pixels
+    output_struct['SIGNAL'][:] = hsp_map[valid_pixels]
+
+    _write_healpix_filename(filename, hdr, output_struct)

--- a/tests/test_healpix_io.py
+++ b/tests/test_healpix_io.py
@@ -1,0 +1,210 @@
+import unittest
+import numpy.testing as testing
+import numpy as np
+import healpy as hp
+from numpy import random
+import tempfile
+import shutil
+import os
+
+import healsparse
+
+
+class HealpixIoTestCase(unittest.TestCase):
+    def test_healpix_implicit_read(self):
+        """Test reading healpix full (implicit) maps."""
+        random.seed(seed=12345)
+
+        nside_coverage = 32
+        nside_map = 64
+
+        n_rand = 1000
+        ra = np.random.random(n_rand) * 360.0
+        dec = np.random.random(n_rand) * 180.0 - 90.0
+
+        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
+
+        # Generate a random map
+        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map[0: 20000] = np.random.random(size=20000)
+
+        ipnest = hp.ang2pix(nside_map, ra, dec, nest=True, lonlat=True)
+
+        test_values = full_map[ipnest]
+
+        filename = os.path.join(self.test_dir, 'healpix_map_ring.fits')
+
+        full_map_ring = hp.reorder(full_map, n2r=True)
+        hp.write_map(filename, full_map_ring, dtype=np.float64)
+
+        # Read it with healsparse
+        sparse_map = healsparse.HealSparseMap.read(filename, nside_coverage=nside_coverage)
+
+        # Check that we can do a basic lookup
+        testing.assert_almost_equal(sparse_map.get_values_pix(ipnest), test_values)
+
+        # Save map to healpy in nest
+        filename = os.path.join(self.test_dir, 'healpix_map_nest.fits')
+        hp.write_map(filename, full_map, dtype=np.float64, nest=True)
+
+        # Read it with healsparse
+        sparse_map = healsparse.HealSparseMap.read(filename, nside_coverage=nside_coverage)
+
+        # Check that we can do a basic lookup
+        testing.assert_almost_equal(sparse_map.get_values_pix(ipnest), test_values)
+
+        # Test that we get an exception if reading without nside_coverage
+        with self.assertRaises(RuntimeError):
+            sparse_map = healsparse.HealSparseMap.read(filename)
+
+    def test_healpix_explicit_read(self):
+        """Test reading healpix partial (explicit) maps."""
+        random.seed(seed=12345)
+
+        nside_coverage = 32
+        nside_map = 64
+
+        n_rand = 1000
+        ra = np.random.random(n_rand) * 360.0
+        dec = np.random.random(n_rand) * 180.0 - 90.0
+
+        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
+
+        # Generate a random map
+        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map[0: 20000] = np.random.random(size=20000)
+
+        ipnest = hp.ang2pix(nside_map, ra, dec, nest=True, lonlat=True)
+
+        test_values = full_map[ipnest]
+
+        filename = os.path.join(self.test_dir, 'healpix_map_ring_explicit.fits')
+
+        full_map_ring = hp.reorder(full_map, n2r=True)
+        hp.write_map(filename, full_map_ring, dtype=np.float64, partial=True)
+
+        # Read it with healsparse
+        sparse_map = healsparse.HealSparseMap.read(filename, nside_coverage=nside_coverage)
+
+        # Check that we can do a basic lookup
+        testing.assert_almost_equal(sparse_map.get_values_pix(ipnest), test_values)
+
+        filename = os.path.join(self.test_dir, 'healpix_map_nest_explicit.fits')
+        hp.write_map(filename, full_map, dtype=np.float64, nest=True, partial=True)
+
+        # Read it with healsparse
+        sparse_map = healsparse.HealSparseMap.read(filename, nside_coverage=nside_coverage)
+
+        # Check that we can do a basic lookup
+        testing.assert_almost_equal(sparse_map.get_values_pix(ipnest), test_values)
+
+    def test_healpix_explicit_write(self):
+        """Test writing healpix partial (explicit) maps (floating point)."""
+        random.seed(seed=12345)
+
+        nside_coverage = 32
+        nside_map = 64
+
+        n_rand = 1000
+        ra = np.random.random(n_rand) * 360.0
+        dec = np.random.random(n_rand) * 180.0 - 90.0
+
+        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
+
+        # Generate a random map
+        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map[0: 20000] = np.random.random(size=20000)
+
+        ipnest = hp.ang2pix(nside_map, ra, dec, nest=True, lonlat=True)
+
+        test_values = full_map[ipnest]
+
+        filename = os.path.join(self.test_dir, 'healsparse_healpix_partial_map.fits')
+
+        sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage, nest=True)
+        sparse_map.write(filename, format='healpix')
+
+        # Read in with healsparse and make sure it is the same.
+        sparse_map2 = healsparse.HealSparseMap.read(filename, nside_coverage=nside_coverage)
+
+        np.testing.assert_array_equal(sparse_map2.valid_pixels, sparse_map.valid_pixels)
+        testing.assert_array_almost_equal(sparse_map2.get_values_pix(ipnest), test_values)
+
+        # Read in with healpy and make sure it is the same.
+        full_map2 = hp.read_map(filename, nest=True)
+        testing.assert_array_equal((full_map2 > hp.UNSEEN).nonzero()[0], sparse_map.valid_pixels)
+        testing.assert_array_almost_equal(full_map2[ipnest], test_values)
+
+    def test_healpix_explicit_int_write(self):
+        """Test writing healpix partial (explicit) maps (integer)."""
+        random.seed(seed=12345)
+
+        nside_coverage = 32
+        nside_map = 64
+
+        n_rand = 1000
+        ra = np.random.random(n_rand) * 360.0
+        dec = np.random.random(n_rand) * 180.0 - 90.0
+
+        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
+
+        # Generate a map
+        full_map = np.zeros(hp.nside2npix(nside_map), dtype=np.int32)
+        full_map[0: 10000] = 4
+        full_map[20000: 30000] = 5
+
+        ipnest = hp.ang2pix(nside_map, ra, dec, nest=True, lonlat=True)
+        test_values = full_map[ipnest]
+
+        filename = os.path.join(self.test_dir, 'healsparse_healpix_int_partial_map.fits')
+
+        sparse_map = healsparse.HealSparseMap(
+            healpix_map=full_map,
+            nside_coverage=nside_coverage,
+            nest=True,
+            sentinel=0
+        )
+        with self.assertWarns(UserWarning):
+            sparse_map.write(filename, format='healpix')
+
+        # Read in with healsparse and make sure it is the same.
+        sparse_map2 = healsparse.HealSparseMap.read(filename, nside_coverage=nside_coverage)
+
+        np.testing.assert_array_equal(sparse_map2.valid_pixels, sparse_map.valid_pixels)
+        testing.assert_almost_equal(sparse_map2.get_values_pix(ipnest), test_values)
+
+        # Read in with healpy and make sure it is the same.
+        full_map2 = hp.read_map(filename, nest=True)
+        testing.assert_array_equal((full_map2 > hp.UNSEEN).nonzero()[0], sparse_map.valid_pixels)
+
+        # healpy will convert all the BAD_DATA to UNSEEN
+        good, = (test_values > 0).nonzero()
+        bad, = (test_values == 0).nonzero()
+        testing.assert_array_equal(full_map2[ipnest[good]], test_values[good])
+        testing.assert_array_almost_equal(full_map2[ipnest[bad]], hp.UNSEEN)
+
+    def test_healpix_recarray_write(self):
+        """Test that the proper error is raised if you try to persist via healpix format."""
+        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
+
+        nside_coverage = 32
+        nside_map = 64
+
+        filename = os.path.join(self.test_dir, 'test_file.fits')
+
+        dtype = [('a', 'f4'), ('b', 'i2')]
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, dtype, primary='a')
+        with self.assertRaises(NotImplementedError):
+            sparse_map.write(filename, format='healpix')
+
+    def setUp(self):
+        self.test_dir = None
+
+    def tearDown(self):
+        if self.test_dir is not None:
+            if os.path.exists(self.test_dir):
+                shutil.rmtree(self.test_dir, True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
@gpdf requested that healsparse be able to write out HEALPix EXPLICIT/PARTIAL maps (https://healpix.sourceforge.io/data/examples/healpix_fits_specs.pdf) without going through healpy and requiring the full sky map.  This was fairly easy to implement, and I also added native support for reading EXPLICIT/PARTIAL maps which will save a significant amount of memory/time when reading in one of these maps.

Note that this is not a preferred way of storing healsparse maps because of loss of coverage map info, compression, and fast partial file reads.