### PR TITLE
Add tests for bool maps (and appropriate fixes).

### DIFF
--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -42,7 +42,7 @@ class HealSparseMap(object):
            Primary key for recarray, required if dtype has fields.
         sentinel : `int` or `float`, optional
            Sentinel value.  Default is `hp.UNSEEN` for floating-point types,
-           and minimum int for int types.
+           minimum int for int types, and False for bool types.
         nest : `bool`, optional
            If input healpix map is in nest format.  Default is True.
         metadata : `dict`-like, optional
@@ -478,6 +478,10 @@ class HealSparseMap(object):
                         raise ValueError("Cannot set non-floating point map with a floating point.")
                     is_single_value = True
                     _values = np.array([values], dtype=self.dtype)
+                elif isinstance(values, (bool, np.bool_)):
+                    is_single_value = True
+                    _values = np.array([values], dtype=bool)
+
         if isinstance(values, np.ndarray) and len(values) == 1:
             is_single_value = True
 
@@ -943,7 +947,7 @@ class HealSparseMap(object):
         if self._is_rec_array:
             return False
 
-        return issubclass(self._sparse_map.dtype.type, np.integer)
+        return issubclass(self._sparse_map.dtype.type, (np.integer, np.bool_))
 
     @property
     def is_unsigned_map(self):
@@ -1293,7 +1297,7 @@ class HealSparseMap(object):
             sparse_map_out = reduce_array(aux, reduction=reduction)
             sentinel_out = self._sentinel
         else:
-            if issubclass(self._sparse_map.dtype.type, np.integer):
+            if issubclass(self._sparse_map.dtype.type, (np.integer, np.bool_)):
                 aux_dtype = np.float64
             else:
                 aux_dtype = self._sparse_map.dtype

--- a/healsparse/io_map_fits.py
+++ b/healsparse/io_map_fits.py
@@ -234,6 +234,10 @@ def _read_healsparse_fits_file(filename, pixels=None):
                                                           nside_sparse,
                                                           _pixels)
 
+    if isinstance(sentinel, bool):
+        # Convert back to boolean
+        sparse_map = sparse_map.astype(bool)
+
     return cov_map, sparse_map, nside_sparse, primary, sentinel
 
 
@@ -491,6 +495,12 @@ def _write_map_fits(hsp_map, filename, clobber=False, nocompress=False):
         _write_filename(filename, c_hdr, s_hdr, hsp_map._cov_map[:], hsp_map._sparse_map.ravel(),
                         compress=not nocompress,
                         compress_tilesize=hsp_map._wide_mask_width*hsp_map._cov_map.nfine_per_cov)
+    elif hsp_map._sparse_map[0].dtype == np.bool_:
+        # We must convert boolean maps to int16 maps for fits storage.
+        _write_filename(filename, c_hdr, s_hdr, hsp_map._cov_map[:], hsp_map._sparse_map.astype(np.int16),
+                        compress=not nocompress,
+                        compress_tilesize=hsp_map._cov_map.nfine_per_cov)
+
     elif ((hsp_map.is_integer_map and hsp_map._sparse_map[0].dtype.itemsize < 8) or
           (not hsp_map.is_integer_map and not hsp_map._is_rec_array)):
         # Integer maps < 64 bit (8 byte) can be compressed, as can

--- a/healsparse/io_map_parquet.py
+++ b/healsparse/io_map_parquet.py
@@ -128,12 +128,16 @@ def _read_map_parquet(healsparse_class, filepath, pixels=None, header=False,
 
     if md['healsparse::sentinel'] == 'UNSEEN':
         sentinel = primary_dtype(hp.UNSEEN)
+    elif md['healsparse::sentinel'] == 'False':
+        sentinel = False
+    elif md['healsparse::sentinel'] == 'True':
+        sentinel = True
     else:
         sentinel = primary_dtype(md['healsparse::sentinel'])
 
         if is_integer_value(sentinel):
             sentinel = int(sentinel)
-        else:
+        elif not isinstance(sentinel, np.bool_):
             sentinel = float(sentinel)
 
     if is_rec_array:

--- a/healsparse/utils.py
+++ b/healsparse/utils.py
@@ -103,6 +103,13 @@ def check_sentinel(type, sentinel):
             return sentinel
         else:
             raise ValueError("Sentinel not of integer type")
+    elif issubclass(type, np.bool_):
+        # If we don't have a sentinel, False
+        if sentinel is None:
+            return False
+        if not isinstance(sentinel, (bool, np.bool_)):
+            raise ValueError("Sentinel not a boolean")
+        return bool(sentinel)
 
 
 def is_integer_value(value):

--- a/tests/test_degrade.py
+++ b/tests/test_degrade.py
@@ -624,6 +624,34 @@ class DegradeMapTestCase(unittest.TestCase):
             testing.assert_almost_equal(sparse_map.coverage_map, sparse_map2.coverage_map)
             testing.assert_almost_equal(sparse_map._sparse_map, sparse_map2._sparse_map)
 
+    def test_degrade_map_bool(self):
+        """
+        Test HealSparse.degrade functionality with bool quantities
+        """
+        random.seed(12345)
+        nside_coverage = 32
+        nside_map = 1024
+        nside_new = 256
+
+        full_map = np.zeros(hp.nside2npix(nside_map), dtype=bool)
+        pixels = np.random.choice(full_map.size, size=full_map.size//4, replace=False)
+        full_map[pixels] = True
+
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, np.bool_)
+        sparse_map[pixels] = full_map[pixels]
+
+        # Degrade original map
+        test_map = full_map.astype(np.float64)
+        test_map[~full_map] = hp.UNSEEN
+        deg_map = hp.ud_grade(test_map, nside_out=nside_new,
+                              order_in='NESTED', order_out='NESTED')
+
+        # Degrade sparse map and compare to original
+        new_map = sparse_map.degrade(nside_out=nside_new)
+
+        # Test the coverage map generation and lookup
+        testing.assert_almost_equal(deg_map, new_map.generate_healpix_map())
+
     def setUp(self):
         self.test_dir = None
 

--- a/tests/test_getset.py
+++ b/tests/test_getset.py
@@ -371,6 +371,33 @@ class GetSetTestCase(unittest.TestCase):
         sparse_map[pxnums[0]] = pxvalues[0]
         testing.assert_equal(sparse_map[pxnums[0]], full_map[pxnums[0]])
 
+        sparse_map[int(pxnums[1])] = int(pxvalues[1])
+        testing.assert_equal(sparse_map[pxnums[1]], full_map[pxnums[1]])
+
+        sparse_map[pxnums] = pxvalues
+        testing.assert_array_almost_equal(sparse_map[pxnums], full_map[pxnums])
+
+    def test_setitem_bool(self):
+        """
+        Test __setitem__ for boolean HealSparseMaps
+        """
+        random.seed(12345)
+        nside_coverage = 32
+        nside_map = 128
+        pxnums = np.arange(0, 2000)
+        pxvalues = np.ones(pxnums.size, dtype=bool)
+        full_map = np.zeros(hp.nside2npix(nside_map), dtype=bool)
+        full_map[pxnums] = pxvalues
+
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage=nside_coverage,
+                                                         nside_sparse=nside_map, dtype=pxvalues.dtype)
+
+        sparse_map[pxnums[0]] = pxvalues[0]
+        testing.assert_equal(sparse_map[pxnums[0]], full_map[pxnums[0]])
+
+        sparse_map[int(pxnums[1])] = bool(pxvalues[1])
+        testing.assert_equal(sparse_map[pxnums[1]], full_map[pxnums[1]])
+
         sparse_map[pxnums] = pxvalues
         testing.assert_array_almost_equal(sparse_map[pxnums], full_map[pxnums])
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -306,10 +306,6 @@ class HealsparseFitsIoTestCase(unittest.TestCase):
         nside_coverage = 32
         nside_map = 64
 
-        n_rand = 1000
-        ra = np.random.random(n_rand) * 360.0
-        dec = np.random.random(n_rand) * 180.0 - 90.0
-
         self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
 
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, bool)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -301,6 +301,52 @@ class HealsparseFitsIoTestCase(unittest.TestCase):
 
         self.assertRaises(IOError, healsparse.HealSparseMap.read, fname)
 
+    def test_fits_writeread_bool(self):
+        """Test writing and reading a bool map."""
+        nside_coverage = 32
+        nside_map = 64
+
+        n_rand = 1000
+        ra = np.random.random(n_rand) * 360.0
+        dec = np.random.random(n_rand) * 180.0 - 90.0
+
+        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
+
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, bool)
+        sparse_map[30000: 30005] = True
+
+        # Write it to healsparse format
+        sparse_map.write(os.path.join(self.test_dir, 'healsparse_map.hs'))
+
+        # Read in healsparse format (full map)
+        sparse_map2 = healsparse.HealSparseMap.read(os.path.join(self.test_dir, 'healsparse_map.hs'))
+
+        # Check that we can do a basic lookup
+        testing.assert_array_equal(sparse_map2[30000: 30005], True)
+
+        self.assertEqual(len(sparse_map2.valid_pixels), 5)
+
+        # Need to read in partial map (slightly different code path)
+        sparse_map3 = healsparse.HealSparseMap.read(
+            os.path.join(self.test_dir, 'healsparse_map.hs'),
+            pixels=sparse_map.coverage_mask.nonzero()[0],
+        )
+
+        # Check that we can do a basic lookup
+        testing.assert_array_equal(sparse_map3[30000: 30005], True)
+
+        self.assertEqual(len(sparse_map3.valid_pixels), 5)
+
+        # And degrade-on-read test ...
+        sparse_map4 = healsparse.HealSparseMap.read(
+            os.path.join(self.test_dir, 'healsparse_map.hs'),
+            degrade_nside=32
+        )
+
+        sparse_map_dg = sparse_map.degrade(32)
+
+        testing.assert_array_almost_equal(sparse_map4._sparse_map, sparse_map_dg._sparse_map)
+
     def setUp(self):
         self.test_dir = None
 

--- a/tests/test_io_parquet.py
+++ b/tests/test_io_parquet.py
@@ -242,10 +242,6 @@ class ParquetIoTestCase(unittest.TestCase):
         nside_coverage = 32
         nside_map = 64
 
-        n_rand = 1000
-        ra = np.random.random(n_rand) * 360.0
-        dec = np.random.random(n_rand) * 180.0 - 90.0
-
         self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
 
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, bool)

--- a/tests/test_io_parquet.py
+++ b/tests/test_io_parquet.py
@@ -237,6 +237,31 @@ class ParquetIoTestCase(unittest.TestCase):
         self.assertRaises(ValueError, sparse_map2.write, fname,
                           format='parquet', nside_io=32)
 
+    def test_parquet_writeread_bool(self):
+        """Test writing and reading a bool map."""
+        nside_coverage = 32
+        nside_map = 64
+
+        n_rand = 1000
+        ra = np.random.random(n_rand) * 360.0
+        dec = np.random.random(n_rand) * 180.0 - 90.0
+
+        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
+
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, bool)
+        sparse_map[30000: 30005] = True
+
+        # Write it to healsparse format
+        sparse_map.write(os.path.join(self.test_dir, 'healsparse_map.hsparquet'), format='parquet')
+
+        # Read in healsparse format (full map)
+        sparse_map2 = healsparse.HealSparseMap.read(os.path.join(self.test_dir, 'healsparse_map.hsparquet'))
+
+        # Check that we can do a basic lookup
+        testing.assert_array_equal(sparse_map2[30000: 30005], True)
+
+        self.assertEqual(len(sparse_map2.valid_pixels), 5)
+
     def setUp(self):
         self.test_dir = None
 

--- a/tests/test_single_datatypes.py
+++ b/tests/test_single_datatypes.py
@@ -77,6 +77,26 @@ class SingleDatatypesTestCase(unittest.TestCase):
         self.assertEqual(sparse_map.dtype, np.uint64)
         self.assertEqual(sparse_map._sentinel, 0)
 
+    def test_datatypes_bools(self):
+        """
+        Test making maps with boolean datatypes
+        """
+        nside_coverage = 32
+        nside_map = 64
+
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, bool)
+
+        self.assertEqual(sparse_map.dtype, np.bool_)
+        self.assertEqual(sparse_map._sentinel, False)
+
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, bool, sentinel=True)
+
+        self.assertEqual(sparse_map.dtype, np.bool_)
+        self.assertEqual(sparse_map._sentinel, True)
+
+        with self.assertRaises(ValueError):
+            sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, bool, sentinel=0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The bool map support was poorly tested and therefore quite buggy.  This PR adds a bunch of tests for boolean maps and fixes the bugs that were revealed.

A lot of the trouble is that `np.bool_` is not related to `bool` in terms of the class hierarchy.