### PR TITLE
Add support for Multi-Order Coverage (MOC) maps

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,6 +34,7 @@ jobs:
         flake8
     - name: Test with pytest
       run: |
+        pip install mocpy
         pytest
         pip install fitsio>=1.0.5
         pytest

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -5,7 +5,7 @@ import numbers
 from .healSparseCoverage import HealSparseCoverage
 from .utils import reduce_array, check_sentinel, _get_field_and_bitval, WIDE_NBIT, WIDE_MASK
 from .utils import is_integer_value, _compute_bitshift
-from .io_map import _read_map, _write_map
+from .io_map import _read_map, _write_map, _write_moc
 import warnings
 
 
@@ -363,6 +363,20 @@ class HealSparseMap(object):
         """
         _write_map(self, filename, clobber=clobber, nocompress=nocompress, format=format,
                    nside_io=nside_io)
+
+    def write_moc(self, filename, clobber=False):
+        """
+        Write the valid pixels of a HealSparseMap to a multi-order component (MOC)
+        file.  Note that values of the pixels are not persisted in MOC format.
+
+        Parameters
+        ----------
+        filename : `str`
+            Name of file to save
+        clobber : `bool`, optional
+            Clobber existing file?  Default is False.
+        """
+        _write_moc(self, filename, clobber=clobber)
 
     def _reserve_cov_pix(self, new_cov_pix):
         """

--- a/healsparse/io_map.py
+++ b/healsparse/io_map.py
@@ -1,7 +1,7 @@
 import os
 
 from .fits_shim import HealSparseFits
-from .io_map_fits import _read_map_fits, _write_map_fits
+from .io_map_fits import _read_map_fits, _write_map_fits, _write_moc_fits
 from .parquet_shim import check_parquet_dataset
 from .io_map_parquet import _read_map_parquet, _write_map_parquet
 from .io_map_healpix import _write_map_healpix
@@ -111,3 +111,20 @@ def _write_map(hsp_map, filename, clobber=False, nocompress=False, format='fits'
         _write_map_healpix(hsp_map, filename, clobber=clobber)
     else:
         raise NotImplementedError("Only 'fits', 'parquet' and 'healpix' file formats are supported.")
+
+
+def _write_moc(hsp_map, filename, clobber=False):
+    """
+    Write the valid pixels of a HealSparseMap to a multi-order component (MOC)
+    file.  Note that values of the pixels are not persisted in MOC format.
+
+    Parameters
+    ----------
+    hsp_map : `healsparse.HealSparseMap`
+        HealSparseMap with valid_pixels to output.
+    filename : `str`
+        Name of file to save
+    clobber : `bool`, optional
+        Clobber existing file?  Default is False.
+    """
+    _write_moc_fits(hsp_map, filename, clobber=clobber)

--- a/tests/test_moc.py
+++ b/tests/test_moc.py
@@ -1,0 +1,122 @@
+import unittest
+import numpy.testing as testing
+import numpy as np
+import healpy as hp
+import tempfile
+import shutil
+import os
+import warnings
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+
+import healsparse
+
+
+class HealsparseMocTestCase(unittest.TestCase):
+    def test_moc_writeread(self):
+        """
+        Test healsparse MOC write/read functionality.
+        """
+        nside_coverage = 32
+        nside_map = 2048
+
+        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
+
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, bool)
+        sparse_map[30000: 70000] = True
+
+        fname = os.path.join(self.test_dir, 'healsparse_moc.fits')
+
+        sparse_map.write_moc(fname)
+
+        bool_map = healsparse.HealSparseMap.read(fname, nside_coverage=nside_coverage)
+
+        # The MOC doesn't store the "native" resolution, so we need to upgrade.
+        bool_map_ug = bool_map.upgrade(nside_map)
+
+        self.assertEqual(len(bool_map_ug.valid_pixels), len(sparse_map.valid_pixels))
+        testing.assert_array_equal(bool_map_ug.valid_pixels, sparse_map.valid_pixels)
+
+    def test_moc_write_hsp_read_mocpy(self):
+        """
+        Test write healsparse MOC and read with mocpy.
+        """
+        try:
+            import mocpy
+        except ImportError:
+            return
+
+        nside_coverage = 32
+        nside_map = 2048
+
+        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
+
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, bool)
+        sparse_map[30000: 70000] = True
+        sparse_map[80000: 90000] = True
+
+        fname = os.path.join(self.test_dir, 'healsparse_moc.fits')
+
+        sparse_map.write_moc(fname)
+
+        # We use the old deprecated interface because the new one can't read
+        # standard FITS files.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            moc = mocpy.MOC.from_fits(fname)
+
+        # There is no mocpy pixel lookup, we must go through ra/dec for some reason.
+        ra, dec = hp.pix2ang(nside_map, np.arange(hp.nside2npix(nside_map)), nest=True, lonlat=True)
+        arr = moc.contains(ra*u.degree, dec*u.degree)
+
+        testing.assert_array_equal(arr.nonzero()[0], sparse_map.valid_pixels)
+
+    def test_moc_write_mocpy_read_hsp(self):
+        """
+        Test write mocpy MOC and read with healsparse.
+        """
+        try:
+            import mocpy
+        except ImportError:
+            return
+
+        nside_coverage = 32
+        nside_map = 2048
+
+        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
+
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, bool)
+        sparse_map[30000: 70000] = True
+        sparse_map[80000: 90000] = True
+
+        fname = os.path.join(self.test_dir, 'mocpy_moc.fits')
+
+        # There is no mocpy pixel setting, we must go through ra/dec for some reason.
+        ra, dec = sparse_map.valid_pixels_pos()
+        skycoords = SkyCoord(ra*u.degree, dec*u.degree)
+        moc = mocpy.MOC.from_skycoords(skycoords, int(np.round(np.log2(nside_map))))
+
+        # We use the old interface to write v1 MOCs since we don't support v2 yet.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            moc.write(fname)
+
+        bool_map = healsparse.HealSparseMap.read(fname, nside_coverage=nside_coverage)
+
+        # The MOC doesn't store the "native" resolution, so we need to upgrade.
+        bool_map_ug = bool_map.upgrade(nside_map)
+
+        self.assertEqual(len(bool_map_ug.valid_pixels), len(sparse_map.valid_pixels))
+        testing.assert_array_equal(bool_map_ug.valid_pixels, sparse_map.valid_pixels)
+
+    def setUp(self):
+        self.test_dir = None
+
+    def tearDown(self):
+        if self.test_dir is not None:
+            if os.path.exists(self.test_dir):
+                shutil.rmtree(self.test_dir, True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds support for reading and writing v1 (NUNIQ) MOC maps: https://www.ivoa.net/documents/MOC/20220317/REC-moc-2.0-20220317.pdf

This may or may not prove useful.