### PR TITLE
Use hpgeom as healpix geometry backend, replacing healpy.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,7 +28,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        pip install .[full]
+        pip install .[full,parquet,healpy]
     - name: Lint with flake8
       run: |
         flake8

--- a/README.md
+++ b/README.md
@@ -1,40 +1,27 @@
 # `healsparse`
 Python implementation of sparse HEALPix maps.
 
-`HealSparse` is a sparse implementation of
-[HEALPix](https://healpix.jpl.nasa.gov/) in Python, written for the Rubin
-Observatory Legacy Survey of Space and Time Dark Energy Science Collaboration
-([DESC](https://lsst-desc.org/)).  `HealSparse` is a pure python library that
-sits on top of [numpy](https://github.com/numpy/numpy) and
-[healpy](https://github.com/healpy/healpy/) and is designed to avoid storing
-full sky maps in case of partial coverage, including easy reading of sub-maps.
-This reduces the overall memory footprint allowing maps to be rendered at
-arcsecond resolution while keeping the familiarity and power of
-[healpy](https://github.com/healpy/healpy/).
+`HealSparse` is a sparse implementation of [HEALPix](https://healpix.jpl.nasa.gov/) in Python, written for the Rubin Observatory Legacy Survey of Space and Time Dark Energy Science Collaboration ([DESC](https://lsst-desc.org/)).
+`HealSparse` is a pure python library that sits on top of [numpy](https://github.com/numpy/numpy) and [hpgeom](https://github.com/LSSTDESC/hpgeom/) and is designed to avoid storing full sky maps in case of partial coverage, including easy reading of sub-maps.
+This reduces the overall memory footprint allowing maps to be rendered at arcsecond resolution while keeping the familiarity and power of [HEALPix](https://healpix.jpl.nasa.gov/).
 
-`HealSparse` expands on [healpy](https://github.com/healpy/healpy/) and
-straight [HEALPix](https://healpix.jpl.nasa.gov/) maps by allowing maps of
-different data types, including 32- and 64-bit floats; 8-, 16-, 32-, and 64-bit
-integers; "wide bit masks" of arbitrary width (allowing hundreds of bits to be
-efficiently and conveniently stored); and
-[numpy](https://github.com/numpy/numpy) record arrays.  Arithmetic operations
-between maps are supported, including sum, product, min/max, and and/or/xor
-bitwise operations for integer maps.  In addition, there is general support for
-any [numpy](https://github.com/numpy/numpy) universal function.
+`HealSparse` expands on functionality available in [healpy](https://github.com/healpy/healpy/) and straight [HEALPix](https://healpix.jpl.nasa.gov/) maps by allowing maps of different data types, including 32- and 64-bit floats; 8-, 16-, 32-, and 64-bit integers; "wide bit masks" of arbitrary width (allowing hundreds of bits to be efficiently and conveniently stored); and [numpy](https://github.com/numpy/numpy) record arrays.
+Arithmetic operations between maps are supported, including sum, product, min/max, and and/or/xor bitwise operations for integer maps.
+In addition, there is general support for any [numpy](https://github.com/numpy/numpy) universal function.
 
-`HealSparse` also includes a simple geometric primitive library, to render
-circles and convex polygons.
+`HealSparse` also includes a simple geometric primitive library, to render circles and convex polygons.
 
 ## Requirements:
 
 `healsparse` requires to have pre-installed the following packages:
 
 - [numpy](https://github.com/numpy/numpy)
-- [healpy](https://github.com/healpy/healpy)
+- [hpgeom](https://github.com/LSSTDESC/hpgeom)
 - [astropy](https://astropy.org)
 
-The following package is optional but recommended for all features:
+The following package is optional but recommended for all features including reading full maps in HEALPix format:
 - [fitsio](https://github.com/esheldon/fitsio)
+- [healpy](https://github.com/healpy/healpy/)
 
 ## Install:
 
@@ -53,16 +40,14 @@ Read the full documentation at https://healsparse.readthedocs.io/en/latest/.
 ## Notes:
 
 The list of released versions of this package can be found
-[here](https://github.com/LSSTDESC/healsparse/releases), with the master branch
+[here](https://github.com/LSSTDESC/healsparse/releases), with the main branch
 including the most recent (non-released) development.
 
 ## Acknowledgements:
 
-The `HealSparse` code was written by Eli Rykoff and Javier Sanchez based on an
-idea from Anže Slosar.
+The `HealSparse` code was written by Eli Rykoff and Javier Sanchez based on an idea from Anže Slosar.
 
 This software was developed under the Rubin Observatory Legacy Survey of Space and Time (LSST) Dark Energy Science Collaboration (DESC) using LSST DESC resources.
 The DESC acknowledges ongoing support from the Institut National de Physique Nucléaire et de Physique des Particules in France; the Science & Technology Facilities Council in the United Kingdom; and the Department of Energy, the National Science Foundation, and the LSST Corporation in the United States.
-DESC uses resources of the IN2P3 Computing Center (CC-IN2P3--Lyon/Villeurbanne - France) funded by the Centre National de la Recherche Scientifique; the National Energy Research Scientific Computing Center, a DOE Office of Science User Facility supported by the Office of Science of the U.S. Department of Energy under Contract No. DE-AC02-05CH11231; STFC DiRAC HPC Facilities, funded by UK BIS National E-infrastructure capital grants; and the UK particle physics grid, supported by the GridPP Collaboration.
+DESC uses resources of the IN2P3 Computing Center (CC-IN2P3--Lyon/Villeurbanne - France) funded by the Centre National de la Recherche Scientifique; the National Energy Research Scientific Computing Center, a DOE Office of Science User Facility supported by the Office of Science of the U.S. Department of Energy under Contract No. DE-AC02-05CH11231; STFC DiRAC HPC Facilities, funded by UK BEIS National E-infrastructure capital grants; and the UK particle physics grid, supported by the GridPP Collaboration.
 This work was performed in part under DOE Contract DE-AC02-76SF00515.
-

--- a/docs/basic_interface.rst
+++ b/docs/basic_interface.rst
@@ -55,7 +55,7 @@ To retrieve values from the map, you can use simple indexing or the explicit API
     >>> 51.0
 
 
-A :code:`HealSparseMap` has the concept of "valid pixels", the pixels over which the map is defined (as opposed to :code:`healpy.UNSEEN` in the case of floating point maps).
+A :code:`HealSparseMap` has the concept of "valid pixels", the pixels over which the map is defined (as opposed to :code:`hpgeom.UNSEEN` in the case of floating point maps).
 You can retrieve the array of valid pixels or the associated positions of the valid pixels easily:
 
 .. code-block :: python
@@ -84,8 +84,8 @@ Integer Maps
 ------------
 
 In addition to floating-point maps, which are natively supported by :code:`healpy`, :code:`HealSparseMap` supports integer maps.
-The "sentinel" value of these maps (equivalent to :code:`healpy.UNSEEN`) is either :code:`-MAXINT` or :code:`0`, depending on the desired use of the map (e.g., integer values or positive bitmasks).
-Note that these maps cannot be trivially converted to :code:`healpy` maps because `HEALPix` has no concept of sentinel values that are not :code:`healpy.UNSEEN`, which is a very large negative floating-point value.
+The "sentinel" value of these maps (equivalent to :code:`hpgeom.UNSEEN`) is either :code:`-MAXINT` or :code:`0`, depending on the desired use of the map (e.g., integer values or positive bitmasks).
+Note that these maps cannot be trivially converted to :code:`healpy` maps because `HEALPix` has no concept of sentinel values that are not :code:`hpgeom.UNSEEN`, which is a very large negative floating-point value.
 
 .. code-block :: python
 
@@ -208,12 +208,12 @@ You can retrieve a boolean array describing which pixels are covered in the map 
 
 .. code-block :: python
 
-    import healpy as hp
+    import hpgeom as hpg
     import matplotlib.pyplot as plt
 
     cov_mask = map3.coverage_mask
     cov_pixels, = np.where(cov_mask)
-    ra, dec = hp.pix2ang(map3.nside_coverage, cov_pixels, lonlat=True, nest=True)
+    ra, dec = hpg.pixel_to_angle(map3.nside_coverage, cov_pixels)
     plt.plot(ra, dec, 'r.')
     plt.show()
 

--- a/docs/filespec.rst
+++ b/docs/filespec.rst
@@ -24,7 +24,7 @@ This is a list of terminology used in a :code:`HealSparseMap` object:
 * :code:`nside_coverage`: The `HEALPix` nside for the coverage map
 * :code:`bit_shift`: The number of bits to shift to convert from :code:`nside_sparse` to :code:`nside_coverage` in the `HEALPix` NEST scheme.  :code:`bit_shift = 2*log_2(nside_sparse/nside_coverage)`.
 * :code:`valid_pixels`: The list of pixels with defined values (:code:`> sentinel`) in the sparse map.
-* :code:`sentinel`: The sentinel value that notes if a pixel is not a valid pixel.  Default is :code:`healpy.UNSEEN` for floating-point maps, :code:`-MAXINT` for integer maps, and :code:`0` for wide mask maps.
+* :code:`sentinel`: The sentinel value that notes if a pixel is not a valid pixel.  Default is :code:`hpgeom.UNSEEN` for floating-point maps, :code:`-MAXINT` for integer maps, and :code:`0` for wide mask maps.
 * :code:`nfine_per_cov`: The number of fine (sparse) pixels per coverage pixel.  :code:`nfine_per_cov = 2**bit_shift`.
 * :code:`wide_mask_width`: The width of a wide mask, in bytes.
 
@@ -62,9 +62,9 @@ An empty :code:`HealSparseMap` is intialized with the following coverage pixel v
 .. code-block :: python
 
     import numpy as np
-    import healpy as hp
+    import hpgeom as hpg
 
-    cov_map[:] = -1*np.arange(hp.nside2npix(nside_coverage), dtype=np.int64)*nfine_per_cov
+    cov_map[:] = -1*np.arange(hpg.nside_to_npixel(nside_coverage), dtype=np.int64)*nfine_per_cov
 
 .. _sparse_map:
 
@@ -197,7 +197,7 @@ The following metadata strings are required:
 * :code:`'healsparse::widemask'`: :code:`'True'` or :code:`'False'`
 * :code:`'healsparse::wwidth'`: :code:`str(wide_mask_width)` or :code:`'1'`
 
-Note that the string :code:`'UNSEEN'` will use the special value :code:`healpy.UNSEEN` to fill empty/overflow pixels.
+Note that the string :code:`'UNSEEN'` will use the special value :code:`hpgeom.UNSEEN` to fill empty/overflow pixels.
 
 Additional metadata from the map is stored as a FITS header string (for compatibility with the FITS serialization) such that:
 * :code:`'healsparse::header'`: :code:`header_string`
@@ -254,4 +254,4 @@ If the sparse map is a numpy record array type, it is stored as a multi-column P
 
 Unlike the FITS serialization, the initial "overflow" coverage pixel is not serialized.
 Instead, on read this is filled in with the :code:`sentinel` value from the Parquet metadata for the :code:`primary` column.
-The other columns in the overflow coverage pixel are filled with the default sentinel for that datatype (e.g., :code:`healpy.UNSEEN` for floating-point columns and :code:`-MAXINT` for integer columns).
+The other columns in the overflow coverage pixel are filled with the default sentinel for that datatype (e.g., :code:`hpgeom.UNSEEN` for floating-point columns and :code:`-MAXINT` for integer columns).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,26 +6,31 @@
 `HealSparse`: A sparse implementation of HEALPix_
 =================================================
 
-`HealSparse` is a sparse implementation of HEALPix_ in Python, written for the Rubin Observatory Legacy Survey of Space and Time Dark Energy Science Collaboration (DESC_).  `HealSparse` is a pure Python library that sits on top of numpy_ and healpy_ and is designed to avoid storing full sky maps in case of partial coverage, including easy reading of sub-maps.  This reduces the overall memory footprint allowing maps to be rendered at arcsecond resolution while keeping the familiarity and power of healpy_.
+`HealSparse` is a sparse implementation of HEALPix_ in Python, written for the Rubin Observatory Legacy Survey of Space and Time Dark Energy Science Collaboration (DESC_).
+`HealSparse` is a pure Python library that sits on top of numpy_ and hpgeom_ and is designed to avoid storing full sky maps in case of partial coverage, including easy reading of sub-maps.
+This reduces the overall memory footprint allowing maps to be rendered at arcsecond resolution while keeping the familiarity and power of HEALPix_.
 
-`HealSparse` expands on healpy_ and straight HEALPix_ maps by allowing maps of different data types, including 32- and 64-bit floats; 8-, 16-, 32-, and 64-bit integers; "wide bit masks" of arbitrary width (allowing hundreds of bits to be efficiently and conveniently stored); and numpy_ record arrays.  Arithmetic operations between maps are supported, including sum, product, min/max, and and/or/xor bitwise operations for integer maps.  In addition, there is general support for any numpy_ universal function.
+`HealSparse` expands on functionality available in healpy_ and straight HEALPix_ maps by allowing maps of different data types, including 32- and 64-bit floats; 8-, 16-, 32-, and 64-bit integers; "wide bit masks" of arbitrary width (allowing hundreds of bits to be efficiently and conveniently stored); and numpy_ record arrays.
+Arithmetic operations between maps are supported, including sum, product, min/max, and and/or/xor bitwise operations for integer maps.
+In addition, there is general support for any numpy_ universal function.
 
 `HealSparse` also includes a simple geometric primitive library, to render circles and convex polygons.
 
 The code is hosted in GitHub_.
 Please use the `issue tracker <https://github.com/LSSTDESC/healsparse/issues>`_ to let us know about any problems or questions with the code.
-The list of released versions of this package can be found `here <https://github.com/LSSTDESC/healsparse/releases>`_, with the master branch including the most recent (non-released) development.
+The list of released versions of this package can be found `here <https://github.com/LSSTDESC/healsparse/releases>`_, with the main branch including the most recent (non-released) development.
 
 The `HealSparse` code was written by Eli Rykoff and Javier Sanchez based on an
 idea from Anže Slosar.
 This software was developed under the Rubin Observatory Legacy Survey of Space and Time (LSST) Dark Energy Science Collaboration (DESC) using LSST DESC resources.
 The DESC acknowledges ongoing support from the Institut National de Physique Nucléaire et de Physique des Particules in France; the Science & Technology Facilities Council in the United Kingdom; and the Department of Energy, the National Science Foundation, and the LSST Corporation in the United States.
-DESC uses resources of the IN2P3 Computing Center (CC-IN2P3--Lyon/Villeurbanne - France) funded by the Centre National de la Recherche Scientifique; the National Energy Research Scientific Computing Center, a DOE Office of Science User Facility supported by the Office of Science of the U.S. Department of Energy under Contract No. DE-AC02-05CH11231; STFC DiRAC HPC Facilities, funded by UK BIS National E-infrastructure capital grants; and the UK particle physics grid, supported by the GridPP Collaboration.
+DESC uses resources of the IN2P3 Computing Center (CC-IN2P3--Lyon/Villeurbanne - France) funded by the Centre National de la Recherche Scientifique; the National Energy Research Scientific Computing Center, a DOE Office of Science User Facility supported by the Office of Science of the U.S. Department of Energy under Contract No. DE-AC02-05CH11231; STFC DiRAC HPC Facilities, funded by UK BEIS National E-infrastructure capital grants; and the UK particle physics grid, supported by the GridPP Collaboration.
 This work was performed in part under DOE Contract DE-AC02-76SF00515.
 
 
 .. _HEALPix: https://healpix.jpl.nasa.gov/
 .. _DESC: https://lsst-desc.org/
+.. _hpgeom: https://github.com/LSSTDESC/hpgeom
 .. _healpy: https://github.com/healpy/healpy/
 .. _GitHub: https://github.com/LSSTDESC/healsparse
 .. _numpy: https://github.com/numpy/numpy

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,23 +1,25 @@
 Install
 =======
 
-`HealSparse` requires `healpy <https://github.com/healpy/healpy/>`_, `numpy <https://github.com/numpy/numpy>`_, and `astropy <https://astropy.org>`_.  If you have `fitsio <https://github.com/esheldon/fitsio>`_ installed then additional features including memory-efficient concatenation of `HealSparse` maps are made available.
+`HealSparse` requires `hpgeom <https://github.com/LSSTDESC/hpgeom/>`_, `numpy <https://github.com/numpy/numpy>`_, and `astropy <https://astropy.org>`_.
+If you have `fitsio <https://github.com/esheldon/fitsio>`_ installed then additional features including memory-efficient concatenation of `HealSparse` maps are made available.
+Installation of `healpy <https://github.com/healpy/healpy>`_ is required for reading full maps in HEALPix format.
 
-`HealSparse` is available at `pypi <https://pypi.org/project/healsparse>`_, and the most convenient way of installing the latest released version is simply:
+`HealSparse` is available at `pypi <https://pypi.org/project/healsparse>`_ and `conda-forge <https://anaconda.org/conda-forge/healsparse>`_, and the most convenient way of installing the latest released version is simply:
 
-.. code-block:: python
+.. code-block:: bash
+
+  conda install -c conda-forge hpgeom
+
+or
+
+.. code-block:: bash
 
   pip install healsparse
 
 To install from source, you can run from the root directory:
 
-.. code-block:: python
-
-  python setup.py install
-
-or use `pip` from the root directory:
-
-.. code-block:: python
+.. code-block:: bash
 
   pip install .
 

--- a/healsparse/cat_healsparse_files.py
+++ b/healsparse/cat_healsparse_files.py
@@ -1,5 +1,5 @@
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 import os
 
 from .healSparseMap import HealSparseMap
@@ -48,7 +48,7 @@ def cat_healsparse_files(file_list, outfile, check_overlap=False, clobber=False,
     for i, f in enumerate(file_list):
         cov_map = HealSparseCoverage.read(f)
 
-        cov_index_map = cov_map[:] + np.arange(hp.nside2npix(cov_map.nside_coverage),
+        cov_index_map = cov_map[:] + np.arange(hpg.nside_to_npixel(cov_map.nside_coverage),
                                                dtype=np.int64)*cov_map.nfine_per_cov
         cov_index_maps.append(cov_index_map)
         cov_map_nfine_per_covs.append(cov_map.nfine_per_cov)
@@ -57,7 +57,7 @@ def cat_healsparse_files(file_list, outfile, check_overlap=False, clobber=False,
             if nside_coverage_out is None:
                 nside_coverage_out = cov_map.nside_coverage
 
-            cov_mask_summary = np.zeros((len(file_list), hp.nside2npix(nside_coverage_out)),
+            cov_mask_summary = np.zeros((len(file_list), hpg.nside_to_npixel(nside_coverage_out)),
                                         dtype=np.bool_)
             nside_sparse = cov_map.nside_sparse
         else:
@@ -113,7 +113,7 @@ def cat_healsparse_files(file_list, outfile, check_overlap=False, clobber=False,
         if 'SENTINEL' in s_hdr:
             sentinel = s_hdr['SENTINEL']
         else:
-            sentinel = hp.UNSEEN
+            sentinel = hpg.UNSEEN
 
         if not fits.ext_is_image('SPARSE'):
             # This is a table extension

--- a/healsparse/healSparseCoverage.py
+++ b/healsparse/healSparseCoverage.py
@@ -1,5 +1,5 @@
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 import warnings
 
 from .utils import _compute_bitshift
@@ -23,7 +23,7 @@ class HealSparseCoverage(object):
         HealSparseCoverage map.
     """
     def __init__(self, cov_index_map, nside_sparse):
-        self._nside_coverage = hp.npix2nside(cov_index_map.size)
+        self._nside_coverage = hpg.npixel_to_nside(cov_index_map.size)
         self._nside_sparse = nside_sparse
         self._cov_index_map = cov_index_map
         self._bit_shift = _compute_bitshift(self._nside_coverage, self._nside_sparse)
@@ -74,7 +74,7 @@ class HealSparseCoverage(object):
         bit_shift = _compute_bitshift(nside_coverage, nside_sparse)
         nfine_per_cov = 2**bit_shift
 
-        cov_index_map = -1*np.arange(hp.nside2npix(nside_coverage), dtype=np.int64)*nfine_per_cov
+        cov_index_map = -1*np.arange(hpg.nside_to_npixel(nside_coverage), dtype=np.int64)*nfine_per_cov
 
         return cls(cov_index_map, nside_sparse)
 
@@ -137,13 +137,13 @@ class HealSparseCoverage(object):
             new_cov_map = self
 
         # Reset to "defaults"
-        cov_index_map_temp = new_cov_map._cov_index_map + np.arange(hp.nside2npix(self.nside_coverage),
+        cov_index_map_temp = new_cov_map._cov_index_map + np.arange(hpg.nside_to_npixel(self.nside_coverage),
                                                                     dtype=np.int64)*self.nfine_per_cov
         # set the new pixels
         cov_index_map_temp[new_cov_pix] = (np.arange(new_cov_pix.size)*self.nfine_per_cov +
                                            sparse_map_size)
         # Restore the offset
-        cov_index_map_temp -= np.arange(hp.nside2npix(self.nside_coverage),
+        cov_index_map_temp -= np.arange(hpg.nside_to_npixel(self.nside_coverage),
                                         dtype=np.int64)*self.nfine_per_cov
 
         new_cov_map._cov_index_map[:] = cov_index_map_temp
@@ -194,7 +194,7 @@ class HealSparseCoverage(object):
            Boolean array of coverage mask.
         """
         cov_mask = (self._cov_index_map[:] +
-                    np.arange(hp.nside2npix(self._nside_coverage)) *
+                    np.arange(hpg.nside_to_npixel(self._nside_coverage)) *
                     self._nfine_per_cov) >= self.nfine_per_cov
         return cov_mask
 
@@ -249,7 +249,7 @@ class HealSparseCoverage(object):
         Compute the mapping from block number to cov_index
         """
         offset_map = (self._cov_index_map[:] +
-                      np.arange(hp.nside2npix(self._nside_coverage)) *
+                      np.arange(hpg.nside_to_npixel(self._nside_coverage)) *
                       self._nfine_per_cov)
         cov_mask = (offset_map >= self.nfine_per_cov)
         cov_pixels, = np.where(cov_mask)

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -310,7 +310,7 @@ class HealSparseMap(object):
         """
         if not nest:
             # must convert map to ring format
-            nside = hpg.npix_to_nside(healpix_map.size)
+            nside = hpg.npixel_to_nside(healpix_map.size)
             if (nside > 128):
                 groupsize = npix // 24
             else:

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -310,7 +310,8 @@ class HealSparseMap(object):
         """
         if not nest:
             # must convert map to ring format
-            nside = hpg.npixel_to_nside(healpix_map.size)
+            npix = healpix_map.size
+            nside = hpg.npixel_to_nside(npix)
             if (nside > 128):
                 groupsize = npix // 24
             else:
@@ -441,8 +442,7 @@ class HealSparseMap(object):
         return self.update_values_pix(hpg.angle_to_pixel(self._nside_sparse,
                                                          ra_or_theta,
                                                          dec_or_phi,
-                                                         lonlat=lonlat,
-                                                         nest=True),
+                                                         lonlat=lonlat),
                                       values,
                                       operation=operation)
 
@@ -689,8 +689,7 @@ class HealSparseMap(object):
         return self.get_values_pix(hpg.angle_to_pixel(self._nside_sparse,
                                                       ra_or_theta,
                                                       dec_or_phi,
-                                                      lonlat=lonlat,
-                                                      nest=True),
+                                                      lonlat=lonlat),
                                    valid_mask=valid_mask)
 
     def get_values_pix(self, pixels, nest=True, valid_mask=False, nside=None):
@@ -777,8 +776,7 @@ class HealSparseMap(object):
         return self.check_bits_pix(hpg.angle_to_pixel(self._nside_sparse,
                                                       ra_or_theta,
                                                       dec_or_phi,
-                                                      lonlat=lonlat,
-                                                      nest=True),
+                                                      lonlat=lonlat),
                                    bits)
 
     def check_bits_pix(self, pixels, bits, nest=True):
@@ -1191,10 +1189,10 @@ class HealSparseMap(object):
         """
         if return_pixels:
             valid_pixels = self.valid_pixels
-            lon, lat = hpg.pixel_to_angle(self.nside_sparse, valid_pixels, lonlat=lonlat, nest=True)
+            lon, lat = hpg.pixel_to_angle(self.nside_sparse, valid_pixels, lonlat=lonlat)
             return (valid_pixels, lon, lat)
         else:
-            return hpg.pixel_to_angle(self.nside_sparse, self.valid_pixels, lonlat=lonlat, nest=True)
+            return hpg.pixel_to_angle(self.nside_sparse, self.valid_pixels, lonlat=lonlat)
 
     @property
     def n_valid(self):

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -309,19 +309,7 @@ class HealSparseMap(object):
            Sparse map of input values.
         """
         if not nest:
-            # must convert map to ring format
-            npix = healpix_map.size
-            nside = hpg.npixel_to_nside(npix)
-            if (nside > 128):
-                groupsize = npix // 24
-            else:
-                groupsize = npix
-
-            healpix_map_nest = np.zeros_like(healpix_map)
-            for group in range(npix // groupsize):
-                pixels = np.arange(group*groupsize, (group + 1)*groupsize)
-                healpix_map_nest[hpg.ring_to_nest(nside, pixels)] = healpix_map[pixels]
-            healpix_map = healpix_map_nest
+            healpix_map = hpg.reorder(healpix_map, ring_to_nest=True)
 
         # Compute the coverage map...
         # Note that this is coming from a standard healpix map so the sentinel

--- a/healsparse/healSparseRandoms.py
+++ b/healsparse/healSparseRandoms.py
@@ -1,6 +1,6 @@
 from __future__ import division, absolute_import, print_function
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 import copy
 
 from .utils import _compute_bitshift
@@ -44,9 +44,9 @@ def make_uniform_randoms_fast(sparse_map, n_random, nside_randoms=2**23, rng=Non
     # The sub-pixels are random from bit_shift
     sub_pixels = rng.randint(0, high=2**bit_shift - 1, size=n_random)
 
-    ra_rand, dec_rand = hp.pix2ang(nside_randoms,
-                                   np.left_shift(ipnest_coarse, bit_shift) + sub_pixels,
-                                   lonlat=True, nest=True)
+    ra_rand, dec_rand = hpg.pixel_to_angle(nside_randoms,
+                                           np.left_shift(ipnest_coarse, bit_shift) + sub_pixels,
+                                           lonlat=True, nest=True)
 
     return ra_rand, dec_rand
 
@@ -85,9 +85,9 @@ def make_uniform_randoms(sparse_map, n_random, rng=None):
     cov_pix, = np.where(cov_mask)
 
     # Get range of coverage pixels
-    cov_theta, cov_phi = hp.pix2ang(sparse_map.nside_coverage, cov_pix, nest=True)
+    cov_theta, cov_phi = hpg.pixel_to_angle(sparse_map.nside_coverage, cov_pix, nest=True, lonlat=False)
 
-    extra_boundary = 2.0 * hp.nside2resol(sparse_map.nside_coverage)
+    extra_boundary = 2.0 * hpg.nside_to_resolution(sparse_map.nside_coverage)
 
     ra_range = np.clip([np.min(cov_phi - extra_boundary),
                         np.max(cov_phi + extra_boundary)],

--- a/healsparse/io_map_fits.py
+++ b/healsparse/io_map_fits.py
@@ -1,6 +1,6 @@
 import os
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 
 from .fits_shim import HealSparseFits, _make_header, _write_filename
 from .utils import is_integer_value, _compute_bitshift, reduce_array, WIDE_MASK
@@ -95,7 +95,7 @@ def _read_map_fits(healsparse_class, filename, nside_coverage=None, pixels=None,
             if 'BAD_DATA' in hdr:
                 sentinel = hdr['BAD_DATA']
             else:
-                sentinel = hp.UNSEEN
+                sentinel = hpg.UNSEEN
 
             healsparse_map = healsparse_class.make_empty(
                 nside_coverage,
@@ -104,11 +104,15 @@ def _read_map_fits(healsparse_class, filename, nside_coverage=None, pixels=None,
                 sentinel=sentinel
             )
             if hdr['ORDERING'] == 'RING':
-                _pix = hp.ring2nest(hdr['NSIDE'], data['PIXEL'])
+                _pix = hpg.ring_to_nest(hdr['NSIDE'], data['PIXEL'])
             else:
                 _pix = data['PIXEL']
             healsparse_map[_pix] = data[signal_column]
         elif hdr['INDXSCHM'].rstrip() == 'IMPLICIT':
+            try:
+                import healpy as hp
+            except ImportError:
+                raise RuntimeError("Cannot read full sky HEALPix maps without healpy.")
             # This is an implicit (full) healpix map
             # Figure out the datatype
             with HealSparseFits(filename) as fits:
@@ -182,7 +186,7 @@ def _read_healsparse_fits_file(filename, pixels=None):
     primary : `str`
         Primary key field for recarray map.  Default is None.
     sentinel : `float` or `int`
-        Sentinel value for null.  Usually hp.UNSEEN
+        Sentinel value for null.  Usually UNSEEN
     """
     cov_map = HealSparseCoverage.read(filename)
     primary = None
@@ -199,7 +203,7 @@ def _read_healsparse_fits_file(filename, pixels=None):
         if 'SENTINEL' in s_hdr:
             sentinel = s_hdr['SENTINEL']
         else:
-            sentinel = hp.UNSEEN
+            sentinel = hpg.UNSEEN
     else:
         _pixels = np.atleast_1d(pixels)
         if len(np.unique(_pixels)) < len(_pixels):
@@ -223,7 +227,7 @@ def _read_healsparse_fits_file(filename, pixels=None):
             if 'SENTINEL' in s_hdr:
                 sentinel = s_hdr['SENTINEL']
             else:
-                sentinel = hp.UNSEEN
+                sentinel = hpg.UNSEEN
 
             if not fits.ext_is_image('SPARSE'):
                 # This is a table extension
@@ -235,7 +239,7 @@ def _read_healsparse_fits_file(filename, pixels=None):
                 wmult = 1
 
             # This is the map without the offset
-            cov_index_map_temp = cov_map[:] + np.arange(hp.nside2npix(nside_coverage),
+            cov_index_map_temp = cov_map[:] + np.arange(hpg.nside_to_npixel(nside_coverage),
                                                         dtype=np.int64)*cov_map.nfine_per_cov
 
             # It is not 100% sure this is the most efficient way to read in,
@@ -329,7 +333,7 @@ def _read_healsparse_fits_file_and_degrade(filename, pixels, nside_out, reductio
                                                       nside_out,
                                                       _pixels)
     # This is the map without the offset
-    cov_index_out_temp = cov_map_out[:] + np.arange(hp.nside2npix(nside_coverage),
+    cov_index_out_temp = cov_map_out[:] + np.arange(hpg.nside_to_npixel(nside_coverage),
                                                     dtype=np.int64)*cov_map_out.nfine_per_cov
     with HealSparseFits(filename) as fits:
         s_hdr = fits.read_ext_header('SPARSE')
@@ -343,7 +347,7 @@ def _read_healsparse_fits_file_and_degrade(filename, pixels, nside_out, reductio
         if 'SENTINEL' in s_hdr:
             sentinel = s_hdr['SENTINEL']
         else:
-            sentinel = hp.UNSEEN
+            sentinel = hpg.UNSEEN
 
         if not fits.ext_is_image('SPARSE'):
             # This is a table extension
@@ -370,7 +374,7 @@ def _read_healsparse_fits_file_and_degrade(filename, pixels, nside_out, reductio
             if 'SENTINEL' in s_hdr_weight:
                 sentinel_weight = s_hdr_weight['SENTINEL']
             else:
-                sentinel_weight = hp.UNSEEN
+                sentinel_weight = hpg.UNSEEN
             if ((s_hdr_weight['NSIDE'] != nside_sparse or
                  not fits.ext_is_image('SPARSE') or
                  'WIDEMASK' in s_hdr_weight or
@@ -394,7 +398,7 @@ def _read_healsparse_fits_file_and_degrade(filename, pixels, nside_out, reductio
                                       dtype=dtype_out)
         elif is_rec_array:
             dtype_out = []
-            sentinel_out = hp.UNSEEN
+            sentinel_out = hpg.UNSEEN
             # We should avoid integers
             test_arr = np.zeros(1, dtype=dtype)
             for key, value in dtype.fields.items():
@@ -417,17 +421,17 @@ def _read_healsparse_fits_file_and_degrade(filename, pixels, nside_out, reductio
                 dtype_out = np.dtype(np.float64)
             else:
                 dtype_out = dtype
-            sentinel_out = hp.UNSEEN
+            sentinel_out = hpg.UNSEEN
             sparse_map_out = np.full((_pixels.size + 1)*nfine_per_cov_out,
                                      sentinel_out,
                                      dtype=dtype_out)
 
         # This is the map without the offset
-        cov_index_map_temp = cov_map[:] + np.arange(hp.nside2npix(nside_coverage),
+        cov_index_map_temp = cov_map[:] + np.arange(hpg.nside_to_npixel(nside_coverage),
                                                     dtype=np.int64)*cov_map.nfine_per_cov
         if use_weightfile:
             cov_index_map_temp_weight = (cov_map_weight[:] +
-                                         np.arange(hp.nside2npix(nside_coverage),
+                                         np.arange(hpg.nside_to_npixel(nside_coverage),
                                                    dtype=np.int64)*cov_map.nfine_per_cov)
 
         for i, pix in enumerate(_pixels):

--- a/healsparse/io_map_fits.py
+++ b/healsparse/io_map_fits.py
@@ -588,7 +588,7 @@ def _write_moc_fits(hsp_map, filename, clobber=False):
     tbl = np.zeros(uniq.size, dtype=[('UNIQ', 'i8')])
     tbl['UNIQ'][:] = uniq
 
-    order = np.round(np.log2(tbl['UNIQ']//4)).astype(np.int32)//2
+    order = np.log2(data['UNIQ']//4).astype(np.int32)//2
     moc_order = np.max(order)
 
     hdu = fits.BinTableHDU(tbl)

--- a/healsparse/io_map_fits.py
+++ b/healsparse/io_map_fits.py
@@ -588,7 +588,7 @@ def _write_moc_fits(hsp_map, filename, clobber=False):
     tbl = np.zeros(uniq.size, dtype=[('UNIQ', 'i8')])
     tbl['UNIQ'][:] = uniq
 
-    order = np.log2(data['UNIQ']//4).astype(np.int32)//2
+    order = np.log2(tbl['UNIQ']//4).astype(np.int32)//2
     moc_order = np.max(order)
 
     hdu = fits.BinTableHDU(tbl)

--- a/healsparse/io_map_parquet.py
+++ b/healsparse/io_map_parquet.py
@@ -1,6 +1,6 @@
 import os
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 import astropy.io.fits as fits
 
 from .utils import is_integer_value, _compute_bitshift, WIDE_MASK
@@ -127,7 +127,7 @@ def _read_map_parquet(healsparse_class, filepath, pixels=None, header=False,
         columns = ['sparse']
 
     if md['healsparse::sentinel'] == 'UNSEEN':
-        sentinel = primary_dtype(hp.UNSEEN)
+        sentinel = primary_dtype(hpg.UNSEEN)
     elif md['healsparse::sentinel'] == 'False':
         sentinel = False
     elif md['healsparse::sentinel'] == 'True':
@@ -245,7 +245,7 @@ def _write_map_parquet(hsp_map, filepath, clobber=False, nside_io=4):
     else:
         wmult = 1
 
-    if np.isclose(hsp_map._sentinel, hp.UNSEEN):
+    if np.isclose(hsp_map._sentinel, hpg.UNSEEN):
         sentinel_string = 'UNSEEN'
     else:
         sentinel_string = str(hsp_map._sentinel)
@@ -278,7 +278,7 @@ def _write_map_parquet(hsp_map, filepath, clobber=False, nside_io=4):
 
     cov_map = hsp_map._cov_map
     sparse_map = hsp_map._sparse_map.ravel()
-    cov_index_map_temp = cov_map[:] + np.arange(hp.nside2npix(hsp_map.nside_coverage),
+    cov_index_map_temp = cov_map[:] + np.arange(hpg.nside_to_npixel(hsp_map.nside_coverage),
                                                 dtype=np.int64)*cov_map.nfine_per_cov
 
     pix_arr = np.zeros(cov_map.nfine_per_cov*wmult, dtype=np.int32)

--- a/healsparse/operations.py
+++ b/healsparse/operations.py
@@ -1,7 +1,5 @@
-from __future__ import division, absolute_import, print_function
-
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 
 from .healSparseMap import HealSparseMap
 from .healSparseCoverage import HealSparseCoverage
@@ -251,7 +249,7 @@ def min_intersection(map_list):
         Element-wise minimum of maps
     """
 
-    return _apply_operation(map_list, np.fmin, -hp.UNSEEN, union=False, int_only=False)
+    return _apply_operation(map_list, np.fmin, -hpg.UNSEEN, union=False, int_only=False)
 
 
 def max_union(map_list):
@@ -287,7 +285,7 @@ def min_union(map_list):
         Element-wise minimum of maps
     """
 
-    return _apply_operation(map_list, np.fmin, -hp.UNSEEN, union=True, int_only=False)
+    return _apply_operation(map_list, np.fmin, -hpg.UNSEEN, union=True, int_only=False)
 
 
 def ufunc_intersection(map_list, func, filler_value=0):

--- a/healsparse/utils.py
+++ b/healsparse/utils.py
@@ -1,5 +1,5 @@
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 import warnings
 import numbers
 
@@ -84,9 +84,9 @@ def check_sentinel(type, sentinel):
     """
 
     if issubclass(type, np.floating):
-        # If we don't have a sentinel, use hp.UNSEEN
+        # If we don't have a sentinel, use hpg.UNSEEN
         if sentinel is None:
-            return hp.UNSEEN
+            return hpg.UNSEEN
         # If input is a float, we're okay.  Otherwise, Raise.
         if isinstance(sentinel, numbers.Real) and not is_integer_value(sentinel):
             return sentinel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.16.0
-healpy
+hpgeom
 astropy
 setuptools_scm
 setuptools_scm_git_archive

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,9 @@ setup(
     author='Eli Rykoff, Javier Sanchez, and others',
     author_email='erykoff@stanford.edu',
     url='https://github.com/lsstdesc/healsparse',
-    install_requires=['numpy', 'healpy', 'astropy'],
-    extras_require={'parquet': ['pyarrow>=5.0.0']},
+    install_requires=['numpy', 'hpgeom', 'astropy'],
+    extras_require={'parquet': ['pyarrow>=5.0.0'],
+                    'healpy': ['healpy']},
     use_scm_version=True,
     setup_requires=['setuptools_scm', 'setuptools_scm_git_archive'],
 )

--- a/tests/test_applymask.py
+++ b/tests/test_applymask.py
@@ -1,9 +1,7 @@
-from __future__ import division, absolute_import, print_function
-
 import unittest
 import numpy.testing as testing
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 
 import healsparse
 
@@ -122,10 +120,10 @@ class ApplyMaskTestCase(unittest.TestCase):
         masked_pixels = mask_map.valid_pixels
 
         # Masked pixels should be zero
-        testing.assert_almost_equal(masked_map.get_values_pix(masked_pixels), hp.UNSEEN)
+        testing.assert_almost_equal(masked_map.get_values_pix(masked_pixels), hpg.UNSEEN)
 
         # Pixels that are in the original but are not in the masked pixels should be 1
-        still_good0, = np.where((float_map.get_values_pix(valid_pixels) > hp.UNSEEN) &
+        still_good0, = np.where((float_map.get_values_pix(valid_pixels) > hpg.UNSEEN) &
                                 (mask_map.get_values_pix(valid_pixels) == 0))
         testing.assert_almost_equal(masked_map.get_values_pix(valid_pixels[still_good0]), 1.0)
 
@@ -137,7 +135,7 @@ class ApplyMaskTestCase(unittest.TestCase):
         masked_pixels = mask_map.valid_pixels
 
         # Masked pixels should be zero
-        testing.assert_almost_equal(masked_map.get_values_pix(masked_pixels), hp.UNSEEN)
+        testing.assert_almost_equal(masked_map.get_values_pix(masked_pixels), hpg.UNSEEN)
 
         # Pixels that are in the original but are not in the masked pixels should be 1
         still_good, = np.where((float_map.get_values_pix(valid_pixels) > 0) &
@@ -160,7 +158,7 @@ class ApplyMaskTestCase(unittest.TestCase):
         masked_pixels = mask_map.valid_pixels
 
         # Masked pixels should be zero
-        testing.assert_almost_equal(float_map.get_values_pix(masked_pixels), hp.UNSEEN)
+        testing.assert_almost_equal(float_map.get_values_pix(masked_pixels), hpg.UNSEEN)
 
         # Pixels that are in the original but are not in the masked pixels should be 1
         testing.assert_almost_equal(float_map.get_values_pix(valid_pixels[still_good0]), 1.0)

--- a/tests/test_astype.py
+++ b/tests/test_astype.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy.testing as testing
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 
 import healsparse
 
@@ -40,7 +40,7 @@ class AstypeCase(unittest.TestCase):
                                           sparse_map_int2[sparse_map.valid_pixels])
         testing.assert_array_equal(sparse_map_int2._sparse_map[0: nfine_per_cov], 0)
 
-        self.assertRaises(ValueError, sparse_map.astype, np.int32, sentinel=hp.UNSEEN)
+        self.assertRaises(ValueError, sparse_map.astype, np.int32, sentinel=hpg.UNSEEN)
 
     def test_int_to_float(self):
         """
@@ -63,7 +63,7 @@ class AstypeCase(unittest.TestCase):
         testing.assert_array_almost_equal(sparse_map[sparse_map.valid_pixels],
                                           sparse_map_float[sparse_map.valid_pixels])
         testing.assert_array_equal(sparse_map_float._sparse_map[0: nfine_per_cov],
-                                   hp.UNSEEN)
+                                   hpg.UNSEEN)
 
         # Convert to a float map with 0 sentinel
         sparse_map_float2 = sparse_map.astype(np.float32, sentinel=0.0)
@@ -110,7 +110,7 @@ class AstypeCase(unittest.TestCase):
                                           sparse_map_int2[sparse_map.valid_pixels])
         testing.assert_array_equal(sparse_map_int2._sparse_map[0: nfine_per_cov], 0)
 
-        self.assertRaises(ValueError, sparse_map.astype, np.int32, sentinel=hp.UNSEEN)
+        self.assertRaises(ValueError, sparse_map.astype, np.int32, sentinel=hpg.UNSEEN)
 
     def test_float_to_float(self):
         """
@@ -133,7 +133,7 @@ class AstypeCase(unittest.TestCase):
         testing.assert_array_almost_equal(sparse_map[sparse_map.valid_pixels],
                                           sparse_map_float[sparse_map.valid_pixels])
         testing.assert_array_equal(sparse_map_float._sparse_map[0: nfine_per_cov],
-                                   hp.UNSEEN)
+                                   hpg.UNSEEN)
 
         # Convert to a different float map with 0 sentinel
         sparse_map_float2 = sparse_map.astype(np.float32, sentinel=0.0)

--- a/tests/test_buildmaps.py
+++ b/tests/test_buildmaps.py
@@ -1,9 +1,7 @@
-from __future__ import division, absolute_import, print_function
-
 import unittest
 import numpy.testing as testing
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 from numpy import random
 
 import healsparse
@@ -27,7 +25,7 @@ class BuildMapsTestCase(unittest.TestCase):
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, np.float64)
 
         # Look up all the values, make sure they're all UNSEEN
-        testing.assert_almost_equal(sparse_map.get_values_pos(ra, dec, lonlat=True), hp.UNSEEN)
+        testing.assert_almost_equal(sparse_map.get_values_pos(ra, dec, lonlat=True), hpg.UNSEEN)
 
         # Fail to append because of wrong dtype
         pixel = np.arange(4000, 20000)
@@ -40,11 +38,9 @@ class BuildMapsTestCase(unittest.TestCase):
         sparse_map.update_values_pix(pixel, values)
 
         # Make a healpix map for comparison
-        hpmap = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        hpmap = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         hpmap[pixel] = values
-        theta = np.radians(90.0 - dec)
-        phi = np.radians(ra)
-        ipnest_test = hp.ang2pix(nside_map, theta, phi, nest=True)
+        ipnest_test = hpg.angle_to_pixel(nside_map, ra, dec, nest=True)
         testing.assert_almost_equal(sparse_map.get_values_pos(ra, dec, lonlat=True), hpmap[ipnest_test])
 
         # Replace the pixels
@@ -115,8 +111,8 @@ class BuildMapsTestCase(unittest.TestCase):
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, dtype, primary='col1')
 
         # Look up all the values, make sure they're all UNSEEN
-        testing.assert_almost_equal(sparse_map.get_values_pos(ra, dec, lonlat=True)['col1'], hp.UNSEEN)
-        testing.assert_almost_equal(sparse_map.get_values_pos(ra, dec, lonlat=True)['col2'], hp.UNSEEN)
+        testing.assert_almost_equal(sparse_map.get_values_pos(ra, dec, lonlat=True)['col1'], hpg.UNSEEN)
+        testing.assert_almost_equal(sparse_map.get_values_pos(ra, dec, lonlat=True)['col2'], hpg.UNSEEN)
 
         pixel = np.arange(4000, 20000)
         values = np.zeros_like(pixel, dtype=dtype)
@@ -125,13 +121,11 @@ class BuildMapsTestCase(unittest.TestCase):
         sparse_map.update_values_pix(pixel, values)
 
         # Make healpix maps for comparison
-        hpmapCol1 = np.zeros(hp.nside2npix(nside_map), dtype=np.float32) + hp.UNSEEN
-        hpmapCol2 = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        hpmapCol1 = np.zeros(hpg.nside_to_npixel(nside_map), dtype=np.float32) + hpg.UNSEEN
+        hpmapCol2 = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         hpmapCol1[pixel] = values['col1']
         hpmapCol2[pixel] = values['col2']
-        theta = np.radians(90.0 - dec)
-        phi = np.radians(ra)
-        ipnest_test = hp.ang2pix(nside_map, theta, phi, nest=True)
+        ipnest_test = hpg.angle_to_pixel(nside_map, ra, dec, nest=True)
         testing.assert_almost_equal(sparse_map.get_values_pos(ra, dec, lonlat=True)['col1'],
                                     hpmapCol1[ipnest_test])
         testing.assert_almost_equal(sparse_map.get_values_pos(ra, dec, lonlat=True)['col2'],
@@ -177,7 +171,7 @@ class BuildMapsTestCase(unittest.TestCase):
         self.assertEqual(len(sparse_map2b._sparse_map),
                          sparse_map2._cov_map.nfine_per_cov*3)
         testing.assert_array_equal(sparse_map2b._sparse_map['col1'], sparse_map._sentinel)
-        testing.assert_array_equal(sparse_map2b._sparse_map['col2'], hp.UNSEEN)
+        testing.assert_array_equal(sparse_map2b._sparse_map['col2'], hpg.UNSEEN)
 
 
 if __name__ == '__main__':

--- a/tests/test_cat_files.py
+++ b/tests/test_cat_files.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy.testing as testing
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 import tempfile
 import shutil
 import os
@@ -30,14 +30,14 @@ class CatFilesTestCase(unittest.TestCase):
                 dtype = np.float64
                 primary = None
                 wide_mask_maxbits = None
-                sentinel = hp.UNSEEN
+                sentinel = hpg.UNSEEN
                 data = np.array([100.0], dtype=dtype)
             elif t == 'recarray':
                 dtype = [('a', 'f4'),
                          ('b', 'i4')]
                 primary = 'a'
                 wide_mask_maxbits = None
-                sentinel = hp.UNSEEN
+                sentinel = hpg.UNSEEN
                 data = np.zeros(1, dtype=dtype)
                 data['a'] = 100.0
                 data['b'] = 100
@@ -143,7 +143,7 @@ class CatFilesTestCase(unittest.TestCase):
                          ('b', 'i4')]
                 primary = 'a'
                 wide_mask_maxbits = None
-                sentinel = hp.UNSEEN
+                sentinel = hpg.UNSEEN
                 data = np.zeros(1, dtype=dtype)
                 data['a'] = 100.0
                 data['b'] = 100

--- a/tests/test_coverage_map.py
+++ b/tests/test_coverage_map.py
@@ -1,9 +1,7 @@
-from __future__ import division, absolute_import, print_function
-
 import unittest
 import numpy.testing as testing
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 import healsparse
 
 
@@ -18,7 +16,7 @@ class CoverageMapTestCase(unittest.TestCase):
         # Number of non-masked pixels in the coverage map resolution
         non_masked_px = 10.5
         nfine = (nside_map//nside_coverage)**2
-        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         full_map[0: int(non_masked_px*nfine)] = 1 + np.random.random(size=int(non_masked_px*nfine))
 
         # Generate sparse map
@@ -47,7 +45,7 @@ class CoverageMapTestCase(unittest.TestCase):
         non_masked_px = 10.5
         nfine = (nside_map//nside_coverage)**2
         sentinel = healsparse.utils.check_sentinel(np.int32, None)
-        full_map = np.zeros(hp.nside2npix(nside_map), dtype=np.int32) + sentinel
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map), dtype=np.int32) + sentinel
         full_map[0: int(non_masked_px*nfine)] = 1
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map,
@@ -125,10 +123,10 @@ class CoverageMapTestCase(unittest.TestCase):
         testing.assert_array_almost_equal(cov_map_orig, cov_map)
 
     def compute_cov_map(self, nside_coverage, non_masked_px, nfine, bit_shift):
-        cov_map_orig = np.zeros(hp.nside2npix(nside_coverage), dtype=np.float64)
+        cov_map_orig = np.zeros(hpg.nside_to_npixel(nside_coverage), dtype=np.float64)
         idx_cov = np.right_shift(np.arange(int(non_masked_px*nfine)), bit_shift)
         unique_idx_cov = np.unique(idx_cov)
-        idx_counts = np.bincount(idx_cov, minlength=hp.nside2npix(nside_coverage)).astype(np.float64)
+        idx_counts = np.bincount(idx_cov, minlength=hpg.nside_to_npixel(nside_coverage)).astype(np.float64)
 
         cov_map_orig[unique_idx_cov] = idx_counts[unique_idx_cov]/nfine
 

--- a/tests/test_coverage_mask.py
+++ b/tests/test_coverage_mask.py
@@ -1,9 +1,7 @@
-from __future__ import division, absolute_import, print_function
-
 import unittest
 import numpy.testing as testing
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 import healsparse
 
 
@@ -17,7 +15,7 @@ class CoverageMaskTestCase(unittest.TestCase):
         # Number of non-masked pixels in the coverage map resolution
         non_masked_px = 10
         nfine = (nside_map//nside_coverage)**2
-        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         full_map[0: non_masked_px*nfine] = 1 + np.random.random(size=non_masked_px*nfine)
 
         # Generate sparse map
@@ -26,7 +24,7 @@ class CoverageMaskTestCase(unittest.TestCase):
 
         # Build the "original" coverage mask
 
-        cov_mask_orig = np.zeros(hp.nside2npix(nside_coverage), dtype=np.bool_)
+        cov_mask_orig = np.zeros(hpg.nside_to_npixel(nside_coverage), dtype=np.bool_)
         idx_cov = np.unique(np.right_shift(np.arange(0, non_masked_px*nfine), sparse_map._cov_map.bit_shift))
         cov_mask_orig[idx_cov] = 1
 

--- a/tests/test_fracdet_map.py
+++ b/tests/test_fracdet_map.py
@@ -1,6 +1,6 @@
 import unittest
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 import healsparse
 
 
@@ -14,7 +14,7 @@ class FracdetTestCase(unittest.TestCase):
         nside_map = 512
         non_masked_px = 10.5
         nfine = (nside_map//nside_coverage)**2
-        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         full_map[0: int(non_masked_px*nfine)] = 1 + np.random.random(size=int(non_masked_px*nfine))
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
@@ -42,7 +42,7 @@ class FracdetTestCase(unittest.TestCase):
         non_masked_px = 10.5
         nfine = (nside_map//nside_coverage)**2
         sentinel = healsparse.utils.check_sentinel(np.int32, None)
-        full_map = np.zeros(hp.nside2npix(nside_map), dtype=np.int32) + sentinel
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map), dtype=np.int32) + sentinel
         full_map[0: int(non_masked_px*nfine)] = 1
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map,
@@ -151,7 +151,7 @@ class FracdetTestCase(unittest.TestCase):
         nside_map = 512
         non_masked_px = 10.5
         nfine = (nside_map//nside_coverage)**2
-        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         full_map[0: int(non_masked_px*nfine)] = 1 + np.random.random(size=int(non_masked_px*nfine))
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
@@ -162,10 +162,10 @@ class FracdetTestCase(unittest.TestCase):
     def compute_fracdet_map(self, nside_map, nside_fracdet, non_masked_px, nfine):
         bit_shift = healsparse.utils._compute_bitshift(nside_fracdet, nside_map)
 
-        fracdet_map_orig = np.zeros(hp.nside2npix(nside_fracdet), dtype=np.float64)
+        fracdet_map_orig = np.zeros(hpg.nside_to_npixel(nside_fracdet), dtype=np.float64)
         idx_frac = np.right_shift(np.arange(int(non_masked_px*nfine)), bit_shift)
         unique_idx_frac = np.unique(idx_frac)
-        idx_counts = np.bincount(idx_frac, minlength=hp.nside2npix(nside_fracdet)).astype(np.float64)
+        idx_counts = np.bincount(idx_frac, minlength=hpg.nside_to_npixel(nside_fracdet)).astype(np.float64)
         nfine_frac = (nside_map//nside_fracdet)**2
         fracdet_map_orig[unique_idx_frac] = idx_counts[unique_idx_frac]/nfine_frac
 

--- a/tests/test_from_healpix.py
+++ b/tests/test_from_healpix.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy.testing as testing
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 
 import healsparse
 
@@ -16,14 +16,14 @@ class GetFromHealpixCase(unittest.TestCase):
         nside_coverage = 32
         nside_map = 128
 
-        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         full_map[0: 5000] = np.random.random(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
         testing.assert_almost_equal(full_map, sparse_map.get_values_pix(np.arange(full_map.size)))
 
         self.assertRaises(ValueError, healsparse.HealSparseMap, healpix_map=full_map,
-                          nside_coverage=nside_coverage, sentinel=int(hp.UNSEEN))
+                          nside_coverage=nside_coverage, sentinel=int(hpg.UNSEEN))
 
     def test_from_healpix_int(self):
         """
@@ -34,7 +34,7 @@ class GetFromHealpixCase(unittest.TestCase):
         nside_coverage = 32
         nside_map = 128
 
-        full_map = np.zeros(hp.nside2npix(nside_map), dtype=np.int32) + np.iinfo(np.int32).min
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map), dtype=np.int32) + np.iinfo(np.int32).min
         full_map[0: 5000] = np.random.poisson(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map,

--- a/tests/test_getset.py
+++ b/tests/test_getset.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy.testing as testing
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 from numpy import random
 
 import healsparse
@@ -17,7 +17,7 @@ class GetSetTestCase(unittest.TestCase):
         nside_coverage = 32
         nside_map = 128
 
-        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         full_map[0: 5000] = random.random(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
@@ -56,8 +56,8 @@ class GetSetTestCase(unittest.TestCase):
         testing.assert_almost_equal(test_item['col2'], values['col2'][1000])
 
         test_item = sparse_map[10000]
-        testing.assert_almost_equal(test_item['col1'], hp.UNSEEN)
-        testing.assert_almost_equal(test_item['col2'], hp.UNSEEN)
+        testing.assert_almost_equal(test_item['col1'], hpg.UNSEEN)
+        testing.assert_almost_equal(test_item['col2'], hpg.UNSEEN)
 
     def test_getitem_slice(self):
         """
@@ -68,7 +68,7 @@ class GetSetTestCase(unittest.TestCase):
         nside_coverage = 32
         nside_map = 128
 
-        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         full_map[0: 5000] = random.random(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
@@ -95,7 +95,7 @@ class GetSetTestCase(unittest.TestCase):
         nside_coverage = 32
         nside_map = 128
 
-        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         full_map[0: 5000] = random.random(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
@@ -117,7 +117,7 @@ class GetSetTestCase(unittest.TestCase):
         nside_coverage = 32
         nside_map = 128
 
-        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         full_map[0: 5000] = random.random(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
@@ -137,7 +137,7 @@ class GetSetTestCase(unittest.TestCase):
         nside_coverage = 32
         nside_map = 128
 
-        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         full_map[0: 5000] = random.random(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
@@ -157,7 +157,7 @@ class GetSetTestCase(unittest.TestCase):
         nside_coverage = 32
         nside_map = 128
 
-        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         full_map[0: 5000] = random.random(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
@@ -243,7 +243,7 @@ class GetSetTestCase(unittest.TestCase):
         nside_coverage = 32
         nside_map = 128
 
-        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         full_map[0: 5000] = random.random(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
@@ -279,7 +279,7 @@ class GetSetTestCase(unittest.TestCase):
         nside_coverage = 32
         nside_map = 128
 
-        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         full_map[0: 5000] = random.random(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
@@ -314,7 +314,7 @@ class GetSetTestCase(unittest.TestCase):
         nside_coverage = 32
         nside_map = 128
 
-        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         full_map[0: 5000] = random.random(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
@@ -343,7 +343,7 @@ class GetSetTestCase(unittest.TestCase):
         nside_coverage = 32
         nside_map = 128
 
-        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         full_map[0: 5000] = random.random(size=5000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
@@ -363,7 +363,7 @@ class GetSetTestCase(unittest.TestCase):
         nside_map = 128
         pxnums = np.arange(0, 2000)
         pxvalues = pxnums
-        full_map = np.zeros(hp.nside2npix(nside_map), dtype=pxvalues.dtype)
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map), dtype=pxvalues.dtype)
         full_map[pxnums] = pxvalues
 
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage=nside_coverage,
@@ -386,7 +386,7 @@ class GetSetTestCase(unittest.TestCase):
         nside_map = 128
         pxnums = np.arange(0, 2000)
         pxvalues = np.ones(pxnums.size, dtype=bool)
-        full_map = np.zeros(hp.nside2npix(nside_map), dtype=bool)
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map), dtype=bool)
         full_map[pxnums] = pxvalues
 
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage=nside_coverage,

--- a/tests/test_healSparseCoverage.py
+++ b/tests/test_healSparseCoverage.py
@@ -1,13 +1,19 @@
 import unittest
 import numpy.testing as testing
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 import tempfile
 import shutil
 import os
 import pytest
 
 import healsparse
+
+try:
+    import healpy as hp
+    has_healpy = True
+except ImportError:
+    has_healpy = False
 
 
 class HealSparseCoverageTestCase(unittest.TestCase):
@@ -29,9 +35,9 @@ class HealSparseCoverageTestCase(unittest.TestCase):
         sparse_map.write(fname)
 
         # Generate a coverage mask from the 0: 20000
-        cov_mask_test = np.zeros(hp.nside2npix(nside_coverage), dtype=np.bool_)
-        theta, phi = hp.pix2ang(nside_map, np.arange(20000), nest=True)
-        ipnest = np.unique(hp.ang2pix(nside_coverage, theta, phi, nest=True))
+        cov_mask_test = np.zeros(hpg.nside_to_npixel(nside_coverage), dtype=np.bool_)
+        ra, dec = hpg.pixel_to_angle(nside_map, np.arange(20000))
+        ipnest = np.unique(hpg.angle_to_pixel(nside_coverage, ra, dec))
         cov_mask_test[ipnest] = True
 
         cov_map = healsparse.HealSparseCoverage.read(fname)
@@ -44,8 +50,11 @@ class HealSparseCoverageTestCase(unittest.TestCase):
         testing.assert_array_equal(cov_map[0: 100], cov_map._cov_index_map[0: 100])
         testing.assert_array_equal([cov_map[0]], [cov_map._cov_index_map[0]])
 
+        if not has_healpy:
+            return
+
         # Make a healpy file and make sure we can't read it
-        test_map = np.zeros(hp.nside2npix(nside_coverage))
+        test_map = np.zeros(hpg.nside_to_npixel(nside_coverage))
         fname = os.path.join(self.test_dir, 'healpy_map_test.fits')
         hp.write_map(fname, test_map)
 
@@ -70,9 +79,9 @@ class HealSparseCoverageTestCase(unittest.TestCase):
         sparse_map.write(fname, format='parquet')
 
         # Generate a coverage mask from the 0: 20000
-        cov_mask_test = np.zeros(hp.nside2npix(nside_coverage), dtype=np.bool_)
-        theta, phi = hp.pix2ang(nside_map, np.arange(20000), nest=True)
-        ipnest = np.unique(hp.ang2pix(nside_coverage, theta, phi, nest=True))
+        cov_mask_test = np.zeros(hpg.nside_to_npixel(nside_coverage), dtype=np.bool_)
+        ra, dec = hpg.pixel_to_angle(nside_map, np.arange(20000))
+        ipnest = np.unique(hpg.angle_to_pixel(nside_coverage, ra, dec))
         cov_mask_test[ipnest] = True
 
         cov_map = healsparse.HealSparseCoverage.read(fname)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy.testing as testing
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 from numpy import random
 import tempfile
 import shutil
@@ -27,10 +27,10 @@ class HealsparseFitsIoTestCase(unittest.TestCase):
         self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
 
         # Generate a random map
-        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         full_map[0: 20000] = np.random.random(size=20000)
 
-        ipnest = hp.ang2pix(nside_map, ra, dec, nest=True, lonlat=True)
+        ipnest = hpg.angle_to_pixel(nside_map, ra, dec)
 
         test_values = full_map[ipnest]
 
@@ -68,14 +68,16 @@ class HealsparseFitsIoTestCase(unittest.TestCase):
         ipnestCov = np.right_shift(ipnest, sparse_map_small._cov_map.bit_shift)
         outside_small, = np.where(ipnestCov > 1)
         test_values2 = test_values.copy()
-        test_values2[outside_small] = hp.UNSEEN
+        test_values2[outside_small] = hpg.UNSEEN
 
         testing.assert_almost_equal(sparse_map_small.get_values_pix(ipnest), test_values2)
 
         # Read in healsparse format (all pixels)
-        sparse_map_full = healsparse.HealSparseMap.read(os.path.join(self.test_dir,
-                                                                     'healsparse_map.hs'),
-                                                        pixels=np.arange(hp.nside2npix(nside_coverage)))
+        sparse_map_full = healsparse.HealSparseMap.read(
+            os.path.join(self.test_dir,
+                         'healsparse_map.hs'),
+            pixels=np.arange(hpg.nside_to_npixel(nside_coverage))
+        )
         testing.assert_almost_equal(sparse_map_full.get_values_pix(ipnest), test_values)
 
     def test_fits_read_outoforder(self):
@@ -111,10 +113,8 @@ class HealsparseFitsIoTestCase(unittest.TestCase):
                                                                 'healsparse_map_outoforder.hs'))
 
         # Test some values
-        theta = np.radians(90.0 - dec)
-        phi = np.radians(ra)
-        ipnest = hp.ang2pix(nside_map, theta, phi)
-        test_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        ipnest = hpg.angle_to_pixel(nside_map, ra, dec)
+        test_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         test_map[pixel] = values
         test_map[pixel2] = values2
 
@@ -130,7 +130,7 @@ class HealsparseFitsIoTestCase(unittest.TestCase):
         ipnest_cov = np.right_shift(ipnest, sparse_map_small._cov_map.bit_shift)
         test_values_small = test_map[ipnest]
         outside_small, = np.where((ipnest_cov != 0) & (ipnest_cov != 1) & (ipnest_cov != 3179))
-        test_values_small[outside_small] = hp.UNSEEN
+        test_values_small[outside_small] = hpg.UNSEEN
 
         testing.assert_almost_equal(sparse_map_small.get_values_pix(ipnest), test_values_small)
 
@@ -145,7 +145,7 @@ class HealsparseFitsIoTestCase(unittest.TestCase):
 
         self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
 
-        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         full_map[0: 20000] = np.random.random(size=20000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map,
@@ -174,10 +174,7 @@ class HealsparseFitsIoTestCase(unittest.TestCase):
         nside_coverage = 128
         nside_map = 2**17
 
-        vec = hp.ang2vec(100.0, 0.0, lonlat=True)
-        rad = np.radians(0.2/60.)
-        pixels = hp.query_disc(nside_map, vec, rad, nest=True, inclusive=False)
-        pixels.sort()
+        pixels = hpg.query_circle(nside_map, 100.0, 0.0, 0.2/60.)
         values = np.zeros(pixels.size, dtype=np.int32) + 8
 
         sparse_map = healsparse.HealSparseMap.make_empty(nside_sparse=nside_map,

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import unittest
 import numpy.testing as testing
 import numpy as np
@@ -35,24 +33,24 @@ class LookupTestCase(unittest.TestCase):
 
         # Test the pixel lookup
         comp_values = sparse_map.get_values_pix(ipnest)
-        testing.assert_almost_equal(comp_values, test_values)
+        testing.assert_array_almost_equal(comp_values, test_values)
 
         # Test pixel lookup (valid pixels)
         # Note that this tests all the downstream functions
         valid_mask = sparse_map.get_values_pix(ipnest, valid_mask=True)
-        testing.assert_equal(valid_mask, comp_values > hp.UNSEEN)
+        testing.assert_array_equal(valid_mask, comp_values > hp.UNSEEN)
 
         # Test pixel lookup (ring)
         ipring = hp.nest2ring(nside_map, ipnest)
         comp_values = sparse_map.get_values_pix(ipring, nest=False)
-        testing.assert_almost_equal(comp_values, test_values)
+        testing.assert_array_almost_equal(comp_values, test_values)
 
         # Test pixel lookup (higher nside)
         comp_values = sparse_map.get_values_pix(
             hp.ang2pix(4096, ra, dec, lonlat=True, nest=True),
             nside=4096
         )
-        testing.assert_almost_equal(comp_values, test_values)
+        testing.assert_array_almost_equal(comp_values, test_values)
 
         # Test pixel lookup (lower nside)
         lowres_pix = hp.ang2pix(256, ra, dec, lonlat=True, nest=True)
@@ -60,29 +58,29 @@ class LookupTestCase(unittest.TestCase):
 
         # Test the theta/phi lookup
         comp_values = sparse_map.get_values_pos(theta, phi, lonlat=False)
-        testing.assert_almost_equal(comp_values, test_values)
+        testing.assert_array_almost_equal(comp_values, test_values)
 
         # Test the ra/dec lookup
         comp_values = sparse_map.get_values_pos(ra, dec, lonlat=True)
-        testing.assert_almost_equal(comp_values, test_values)
+        testing.assert_array_almost_equal(comp_values, test_values)
 
         # Test the list of valid pixels
         valid_pixels = sparse_map.valid_pixels
-        testing.assert_equal(valid_pixels, np.where(full_map > hp.UNSEEN)[0])
+        testing.assert_array_equal(valid_pixels, np.where(full_map > hp.UNSEEN)[0])
 
         # Test the position of valid pixels
         ra_sp, dec_sp = sparse_map.valid_pixels_pos(lonlat=True)
         _ra_sp, _dec_sp = hp.pix2ang(nside_map, np.where(full_map > hp.UNSEEN)[0], lonlat=True, nest=True)
-        testing.assert_equal(ra_sp, _ra_sp)
-        testing.assert_equal(dec_sp, _dec_sp)
+        testing.assert_array_almost_equal(ra_sp, _ra_sp)
+        testing.assert_array_almost_equal(dec_sp, _dec_sp)
 
         # Test position of valid pixels and valid pixels
         valid_pixels, ra_sp, dec_sp = sparse_map.valid_pixels_pos(lonlat=True,
                                                                   return_pixels=True)
         _ra_sp, _dec_sp = hp.pix2ang(nside_map, np.where(full_map > hp.UNSEEN)[0], lonlat=True, nest=True)
-        testing.assert_equal(ra_sp, _ra_sp)
-        testing.assert_equal(dec_sp, _dec_sp)
-        testing.assert_equal(valid_pixels, np.where(full_map > hp.UNSEEN)[0])
+        testing.assert_array_almost_equal(ra_sp, _ra_sp)
+        testing.assert_array_almost_equal(dec_sp, _dec_sp)
+        testing.assert_array_equal(valid_pixels, np.where(full_map > hp.UNSEEN)[0])
 
 
 if __name__ == '__main__':

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy.testing as testing
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 
 import healsparse
 
@@ -16,7 +16,7 @@ class LookupTestCase(unittest.TestCase):
         nside_coverage = 32
         nside_map = 1024
 
-        full_map = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         full_map[0: 200000] = np.random.random(size=200000)
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
@@ -25,9 +25,9 @@ class LookupTestCase(unittest.TestCase):
         ra = np.random.random(n_rand) * 360.0
         dec = np.random.random(n_rand) * 180.0 - 90.0
 
-        theta = np.radians(90.0 - dec)
-        phi = np.radians(ra)
-        ipnest = hp.ang2pix(nside_map, theta, phi, nest=True)
+        theta, phi = hpg.lonlat_to_thetaphi(ra, dec)
+
+        ipnest = hpg.angle_to_pixel(nside_map, ra, dec)
 
         test_values = full_map[ipnest]
 
@@ -38,22 +38,22 @@ class LookupTestCase(unittest.TestCase):
         # Test pixel lookup (valid pixels)
         # Note that this tests all the downstream functions
         valid_mask = sparse_map.get_values_pix(ipnest, valid_mask=True)
-        testing.assert_array_equal(valid_mask, comp_values > hp.UNSEEN)
+        testing.assert_array_equal(valid_mask, comp_values > hpg.UNSEEN)
 
         # Test pixel lookup (ring)
-        ipring = hp.nest2ring(nside_map, ipnest)
+        ipring = hpg.nest_to_ring(nside_map, ipnest)
         comp_values = sparse_map.get_values_pix(ipring, nest=False)
         testing.assert_array_almost_equal(comp_values, test_values)
 
         # Test pixel lookup (higher nside)
         comp_values = sparse_map.get_values_pix(
-            hp.ang2pix(4096, ra, dec, lonlat=True, nest=True),
+            hpg.angle_to_pixel(4096, ra, dec),
             nside=4096
         )
         testing.assert_array_almost_equal(comp_values, test_values)
 
         # Test pixel lookup (lower nside)
-        lowres_pix = hp.ang2pix(256, ra, dec, lonlat=True, nest=True)
+        lowres_pix = hpg.angle_to_pixel(256, ra, dec)
         self.assertRaises(ValueError, sparse_map.get_values_pix, lowres_pix, nside=256)
 
         # Test the theta/phi lookup
@@ -66,21 +66,21 @@ class LookupTestCase(unittest.TestCase):
 
         # Test the list of valid pixels
         valid_pixels = sparse_map.valid_pixels
-        testing.assert_array_equal(valid_pixels, np.where(full_map > hp.UNSEEN)[0])
+        testing.assert_array_equal(valid_pixels, np.where(full_map > hpg.UNSEEN)[0])
 
         # Test the position of valid pixels
         ra_sp, dec_sp = sparse_map.valid_pixels_pos(lonlat=True)
-        _ra_sp, _dec_sp = hp.pix2ang(nside_map, np.where(full_map > hp.UNSEEN)[0], lonlat=True, nest=True)
+        _ra_sp, _dec_sp = hpg.pixel_to_angle(nside_map, np.where(full_map > hpg.UNSEEN)[0])
         testing.assert_array_almost_equal(ra_sp, _ra_sp)
         testing.assert_array_almost_equal(dec_sp, _dec_sp)
 
         # Test position of valid pixels and valid pixels
         valid_pixels, ra_sp, dec_sp = sparse_map.valid_pixels_pos(lonlat=True,
                                                                   return_pixels=True)
-        _ra_sp, _dec_sp = hp.pix2ang(nside_map, np.where(full_map > hp.UNSEEN)[0], lonlat=True, nest=True)
+        _ra_sp, _dec_sp = hpg.pixel_to_angle(nside_map, np.where(full_map > hpg.UNSEEN)[0])
         testing.assert_array_almost_equal(ra_sp, _ra_sp)
         testing.assert_array_almost_equal(dec_sp, _dec_sp)
-        testing.assert_array_equal(valid_pixels, np.where(full_map > hp.UNSEEN)[0])
+        testing.assert_array_equal(valid_pixels, np.where(full_map > hpg.UNSEEN)[0])
 
 
 if __name__ == '__main__':

--- a/tests/test_moc.py
+++ b/tests/test_moc.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy.testing as testing
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 import tempfile
 import shutil
 import os
@@ -66,7 +66,7 @@ class HealsparseMocTestCase(unittest.TestCase):
             moc = mocpy.MOC.from_fits(fname)
 
         # There is no mocpy pixel lookup, we must go through ra/dec for some reason.
-        ra, dec = hp.pix2ang(nside_map, np.arange(hp.nside2npix(nside_map)), nest=True, lonlat=True)
+        ra, dec = hpg.pixel_to_angle(nside_map, np.arange(hpg.nside_to_npixel(nside_map)))
         arr = moc.contains(ra*u.degree, dec*u.degree)
 
         testing.assert_array_equal(arr.nonzero()[0], sparse_map.valid_pixels)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,9 +1,7 @@
-from __future__ import division, absolute_import, print_function
-
 import unittest
 import numpy.testing as testing
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 from numpy import random
 
 import healsparse
@@ -14,7 +12,6 @@ class OperationsTestCase(unittest.TestCase):
         """
         Test map addition.
         """
-
         random.seed(seed=12345)
 
         nside_coverage = 32
@@ -46,8 +43,8 @@ class OperationsTestCase(unittest.TestCase):
         # sum 2
         added_map_intersection = healsparse.sum_intersection([sparse_map1, sparse_map2])
 
-        gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN))
-        hpmap_sum_intersection = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where((hpmap1 > hpg.UNSEEN) & (hpmap2 > hpg.UNSEEN))
+        hpmap_sum_intersection = np.zeros_like(hpmap1) + hpg.UNSEEN
         hpmap_sum_intersection[gd] = hpmap1[gd] + hpmap2[gd]
 
         testing.assert_almost_equal(hpmap_sum_intersection, added_map_intersection.generate_healpix_map())
@@ -55,8 +52,8 @@ class OperationsTestCase(unittest.TestCase):
         # sum 3
         added_map_intersection = healsparse.sum_intersection([sparse_map1, sparse_map2, sparse_map3])
 
-        gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN) & (hpmap3 > hp.UNSEEN))
-        hpmap_sum_intersection = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where((hpmap1 > hpg.UNSEEN) & (hpmap2 > hpg.UNSEEN) & (hpmap3 > hpg.UNSEEN))
+        hpmap_sum_intersection = np.zeros_like(hpmap1) + hpg.UNSEEN
         hpmap_sum_intersection[gd] = hpmap1[gd] + hpmap2[gd] + hpmap3[gd]
 
         testing.assert_almost_equal(hpmap_sum_intersection, added_map_intersection.generate_healpix_map())
@@ -66,8 +63,8 @@ class OperationsTestCase(unittest.TestCase):
         # sum 2
         added_map_union = healsparse.sum_union([sparse_map1, sparse_map2])
 
-        gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN))
-        hpmap_sum_union = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where((hpmap1 > hpg.UNSEEN) | (hpmap2 > hpg.UNSEEN))
+        hpmap_sum_union = np.zeros_like(hpmap1) + hpg.UNSEEN
         # This hack works because we don't have summands going below zero...
         hpmap_sum_union[gd] = np.clip(hpmap1[gd], 0.0, None) + np.clip(hpmap2[gd], 0.0, None)
 
@@ -76,8 +73,8 @@ class OperationsTestCase(unittest.TestCase):
         # sum 3
         added_map_union = healsparse.sum_union([sparse_map1, sparse_map2, sparse_map3])
 
-        gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN) | (hpmap3 > hp.UNSEEN))
-        hpmap_sum_union = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where((hpmap1 > hpg.UNSEEN) | (hpmap2 > hpg.UNSEEN) | (hpmap3 > hpg.UNSEEN))
+        hpmap_sum_union = np.zeros_like(hpmap1) + hpg.UNSEEN
         # This hack works because we don't have summands going below zero...
         hpmap_sum_union[gd] = (np.clip(hpmap1[gd], 0.0, None) +
                                np.clip(hpmap2[gd], 0.0, None) +
@@ -89,8 +86,8 @@ class OperationsTestCase(unittest.TestCase):
 
         added_map = sparse_map1 + 2
 
-        hpmapAdd2 = np.zeros_like(hpmap1) + hp.UNSEEN
-        gd, = np.where(hpmap1 > hp.UNSEEN)
+        hpmapAdd2 = np.zeros_like(hpmap1) + hpg.UNSEEN
+        gd, = np.where(hpmap1 > hpg.UNSEEN)
         hpmapAdd2[gd] = hpmap1[gd] + 2
 
         testing.assert_almost_equal(hpmapAdd2, added_map.generate_healpix_map())
@@ -99,8 +96,8 @@ class OperationsTestCase(unittest.TestCase):
 
         added_map = sparse_map1 + 2.0
 
-        hpmapAdd2 = np.zeros_like(hpmap1) + hp.UNSEEN
-        gd, = np.where(hpmap1 > hp.UNSEEN)
+        hpmapAdd2 = np.zeros_like(hpmap1) + hpg.UNSEEN
+        gd, = np.where(hpmap1 > hpg.UNSEEN)
         hpmapAdd2[gd] = hpmap1[gd] + 2.0
 
         testing.assert_almost_equal(hpmapAdd2, added_map.generate_healpix_map())
@@ -147,8 +144,8 @@ class OperationsTestCase(unittest.TestCase):
         # product of 2
         product_map_intersection = healsparse.product_intersection([sparse_map1, sparse_map2])
 
-        gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN))
-        hpmap_product_intersection = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where((hpmap1 > hpg.UNSEEN) & (hpmap2 > hpg.UNSEEN))
+        hpmap_product_intersection = np.zeros_like(hpmap1) + hpg.UNSEEN
         hpmap_product_intersection[gd] = hpmap1[gd] * hpmap2[gd]
 
         testing.assert_almost_equal(hpmap_product_intersection,
@@ -157,8 +154,8 @@ class OperationsTestCase(unittest.TestCase):
         # product of 3
         product_map_intersection = healsparse.product_intersection([sparse_map1, sparse_map2, sparse_map3])
 
-        gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN) & (hpmap3 > hp.UNSEEN))
-        hpmap_product_intersection = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where((hpmap1 > hpg.UNSEEN) & (hpmap2 > hpg.UNSEEN) & (hpmap3 > hpg.UNSEEN))
+        hpmap_product_intersection = np.zeros_like(hpmap1) + hpg.UNSEEN
         hpmap_product_intersection[gd] = hpmap1[gd] * hpmap2[gd] * hpmap3[gd]
 
         testing.assert_almost_equal(hpmap_product_intersection,
@@ -169,13 +166,13 @@ class OperationsTestCase(unittest.TestCase):
         # product of 2
         product_map_union = healsparse.product_union([sparse_map1, sparse_map2])
 
-        gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN))
-        hpmap_product_union = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where((hpmap1 > hpg.UNSEEN) | (hpmap2 > hpg.UNSEEN))
+        hpmap_product_union = np.zeros_like(hpmap1) + hpg.UNSEEN
 
         hpmap_product_union[gd] = 1.0
-        gd1, = np.where(hpmap1[gd] > hp.UNSEEN)
+        gd1, = np.where(hpmap1[gd] > hpg.UNSEEN)
         hpmap_product_union[gd[gd1]] *= hpmap1[gd[gd1]]
-        gd2, = np.where(hpmap2[gd] > hp.UNSEEN)
+        gd2, = np.where(hpmap2[gd] > hpg.UNSEEN)
         hpmap_product_union[gd[gd2]] *= hpmap2[gd[gd2]]
 
         testing.assert_almost_equal(hpmap_product_union, product_map_union.generate_healpix_map())
@@ -183,15 +180,15 @@ class OperationsTestCase(unittest.TestCase):
         # product 3
         product_map_union = healsparse.product_union([sparse_map1, sparse_map2, sparse_map3])
 
-        gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN) | (hpmap3 > hp.UNSEEN))
-        hpmap_product_union = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where((hpmap1 > hpg.UNSEEN) | (hpmap2 > hpg.UNSEEN) | (hpmap3 > hpg.UNSEEN))
+        hpmap_product_union = np.zeros_like(hpmap1) + hpg.UNSEEN
 
         hpmap_product_union[gd] = 1.0
-        gd1, = np.where(hpmap1[gd] > hp.UNSEEN)
+        gd1, = np.where(hpmap1[gd] > hpg.UNSEEN)
         hpmap_product_union[gd[gd1]] *= hpmap1[gd[gd1]]
-        gd2, = np.where(hpmap2[gd] > hp.UNSEEN)
+        gd2, = np.where(hpmap2[gd] > hpg.UNSEEN)
         hpmap_product_union[gd[gd2]] *= hpmap2[gd[gd2]]
-        gd3, = np.where(hpmap3[gd] > hp.UNSEEN)
+        gd3, = np.where(hpmap3[gd] > hpg.UNSEEN)
         hpmap_product_union[gd[gd3]] *= hpmap3[gd[gd3]]
 
         testing.assert_almost_equal(hpmap_product_union, product_map_union.generate_healpix_map())
@@ -200,8 +197,8 @@ class OperationsTestCase(unittest.TestCase):
 
         mult_map = sparse_map1 * 2
 
-        hpmap_product2 = np.zeros_like(hpmap1) + hp.UNSEEN
-        gd, = np.where(hpmap1 > hp.UNSEEN)
+        hpmap_product2 = np.zeros_like(hpmap1) + hpg.UNSEEN
+        gd, = np.where(hpmap1 > hpg.UNSEEN)
         hpmap_product2[gd] = hpmap1[gd] * 2
 
         testing.assert_almost_equal(hpmap_product2, mult_map.generate_healpix_map())
@@ -210,8 +207,8 @@ class OperationsTestCase(unittest.TestCase):
 
         mult_map = sparse_map1 * 2.0
 
-        hpmap_product2 = np.zeros_like(hpmap1) + hp.UNSEEN
-        gd, = np.where(hpmap1 > hp.UNSEEN)
+        hpmap_product2 = np.zeros_like(hpmap1) + hpg.UNSEEN
+        gd, = np.where(hpmap1 > hpg.UNSEEN)
         hpmap_product2[gd] = hpmap1[gd] * 2.0
 
         testing.assert_almost_equal(hpmap_product2, mult_map.generate_healpix_map())
@@ -247,7 +244,7 @@ class OperationsTestCase(unittest.TestCase):
         values1 = random.randint(low=1, high=maxval, size=pixel1.size)
         sparse_map1.update_values_pix(pixel1, values1)
 
-        hpmap1 = np.zeros(hp.nside2npix(nside_map), dtype=np.int64)
+        hpmap1 = np.zeros(hpg.nside_to_npixel(nside_map), dtype=np.int64)
         vpix = sparse_map1.valid_pixels
         hpmap1[vpix] = sparse_map1.get_values_pix(vpix)
 
@@ -261,7 +258,7 @@ class OperationsTestCase(unittest.TestCase):
         values2 = random.randint(low=1, high=maxval, size=pixel2.size)
         sparse_map2.update_values_pix(pixel2, values2)
 
-        hpmap2 = np.zeros(hp.nside2npix(nside_map), dtype=np.int64)
+        hpmap2 = np.zeros(hpg.nside_to_npixel(nside_map), dtype=np.int64)
         vpix = sparse_map2.valid_pixels
         hpmap2[vpix] = sparse_map2.get_values_pix(vpix)
 
@@ -275,7 +272,7 @@ class OperationsTestCase(unittest.TestCase):
         values3 = random.randint(low=1, high=maxval, size=pixel3.size)
         sparse_map3.update_values_pix(pixel3, values3)
 
-        hpmap3 = np.zeros(hp.nside2npix(nside_map), dtype=np.int64)
+        hpmap3 = np.zeros(hpg.nside_to_npixel(nside_map), dtype=np.int64)
         vpix = sparse_map3.valid_pixels
         hpmap3[vpix] = sparse_map3.get_values_pix(vpix)
 
@@ -288,7 +285,7 @@ class OperationsTestCase(unittest.TestCase):
         hpmap_product_intersection = np.zeros_like(hpmap1)
         hpmap_product_intersection[gd] = hpmap1[gd] * hpmap2[gd]
 
-        pmap = np.zeros(hp.nside2npix(nside_map), dtype=np.int64)
+        pmap = np.zeros(hpg.nside_to_npixel(nside_map), dtype=np.int64)
         vpix = product_map_intersection.valid_pixels
         pmap[vpix] = product_map_intersection.get_values_pix(vpix)
 
@@ -301,7 +298,7 @@ class OperationsTestCase(unittest.TestCase):
         hpmap_product_intersection = np.zeros_like(hpmap1)
         hpmap_product_intersection[gd] = hpmap1[gd] * hpmap2[gd] * hpmap3[gd]
 
-        pmap = np.zeros(hp.nside2npix(nside_map), dtype=np.int64)
+        pmap = np.zeros(hpg.nside_to_npixel(nside_map), dtype=np.int64)
         vpix = product_map_intersection.valid_pixels
         pmap[vpix] = product_map_intersection.get_values_pix(vpix)
 
@@ -321,7 +318,7 @@ class OperationsTestCase(unittest.TestCase):
         gd2, = np.where(hpmap2[gd] > sentinel)
         hpmap_product_union[gd[gd2]] *= hpmap2[gd[gd2]]
 
-        pmap = np.zeros(hp.nside2npix(nside_map), dtype=np.int64)
+        pmap = np.zeros(hpg.nside_to_npixel(nside_map), dtype=np.int64)
         vpix = product_map_union.valid_pixels
         pmap[vpix] = product_map_union.get_values_pix(vpix)
 
@@ -341,7 +338,7 @@ class OperationsTestCase(unittest.TestCase):
         gd3, = np.where(hpmap3[gd] > sentinel)
         hpmap_product_union[gd[gd3]] *= hpmap3[gd[gd3]]
 
-        pmap = np.zeros(hp.nside2npix(nside_map), dtype=np.int64)
+        pmap = np.zeros(hpg.nside_to_npixel(nside_map), dtype=np.int64)
         vpix = product_map_union.valid_pixels
         pmap[vpix] = product_map_union.get_values_pix(vpix)
 
@@ -355,7 +352,7 @@ class OperationsTestCase(unittest.TestCase):
         gd, = np.where(hpmap1 > sentinel)
         hpmap_product2[gd] = hpmap1[gd] * 2
 
-        pmap = np.zeros(hp.nside2npix(nside_map), dtype=np.int64)
+        pmap = np.zeros(hpg.nside_to_npixel(nside_map), dtype=np.int64)
         vpix = mult_map.valid_pixels
         pmap[vpix] = mult_map.get_values_pix(vpix)
 
@@ -397,8 +394,8 @@ class OperationsTestCase(unittest.TestCase):
             # or 2
             or_map_intersection = healsparse.or_intersection([sparse_map1, sparse_map2])
 
-            gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN))
-            hpmap_or_intersection = np.zeros_like(hpmap1) + hp.UNSEEN
+            gd, = np.where((hpmap1 > hpg.UNSEEN) & (hpmap2 > hpg.UNSEEN))
+            hpmap_or_intersection = np.zeros_like(hpmap1) + hpg.UNSEEN
             hpmap_or_intersection[gd] = hpmap1[gd].astype(dtype) | hpmap2[gd].astype(dtype)
 
             testing.assert_almost_equal(hpmap_or_intersection, or_map_intersection.generate_healpix_map())
@@ -406,8 +403,8 @@ class OperationsTestCase(unittest.TestCase):
             # or 3
             or_map_intersection = healsparse.or_intersection([sparse_map1, sparse_map2, sparse_map3])
 
-            gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN) & (hpmap3 > hp.UNSEEN))
-            hpmap_or_intersection = np.zeros_like(hpmap1) + hp.UNSEEN
+            gd, = np.where((hpmap1 > hpg.UNSEEN) & (hpmap2 > hpg.UNSEEN) & (hpmap3 > hpg.UNSEEN))
+            hpmap_or_intersection = np.zeros_like(hpmap1) + hpg.UNSEEN
             hpmap_or_intersection[gd] = (hpmap1[gd].astype(dtype) |
                                          hpmap2[gd].astype(dtype) |
                                          hpmap3[gd].astype(dtype))
@@ -419,8 +416,8 @@ class OperationsTestCase(unittest.TestCase):
             # or 2
             or_map_union = healsparse.or_union([sparse_map1, sparse_map2])
 
-            gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN))
-            hpmap_or_union = np.zeros_like(hpmap1) + hp.UNSEEN
+            gd, = np.where((hpmap1 > hpg.UNSEEN) | (hpmap2 > hpg.UNSEEN))
+            hpmap_or_union = np.zeros_like(hpmap1) + hpg.UNSEEN
             hpmap_or_union[gd] = (np.clip(hpmap1[gd], 0.0, None).astype(dtype) |
                                   np.clip(hpmap2[gd], 0.0, None).astype(dtype))
 
@@ -429,8 +426,8 @@ class OperationsTestCase(unittest.TestCase):
             # or 3
             or_map_union = healsparse.or_union([sparse_map1, sparse_map2, sparse_map3])
 
-            gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN) | (hpmap3 > hp.UNSEEN))
-            hpmap_or_union = np.zeros_like(hpmap1) + hp.UNSEEN
+            gd, = np.where((hpmap1 > hpg.UNSEEN) | (hpmap2 > hpg.UNSEEN) | (hpmap3 > hpg.UNSEEN))
+            hpmap_or_union = np.zeros_like(hpmap1) + hpg.UNSEEN
             hpmap_or_union[gd] = (np.clip(hpmap1[gd], 0.0, None).astype(dtype) |
                                   np.clip(hpmap2[gd], 0.0, None).astype(dtype) |
                                   np.clip(hpmap3[gd], 0.0, None).astype(dtype))
@@ -441,8 +438,8 @@ class OperationsTestCase(unittest.TestCase):
 
             or_map = sparse_map1 | 2
 
-            hpmap_or2 = np.zeros_like(hpmap1) + hp.UNSEEN
-            gd, = np.where(hpmap1 > hp.UNSEEN)
+            hpmap_or2 = np.zeros_like(hpmap1) + hpg.UNSEEN
+            gd, = np.where(hpmap1 > hpg.UNSEEN)
             hpmap_or2[gd] = hpmap1[gd].astype(dtype) | 2
             testing.assert_almost_equal(hpmap_or2, or_map.generate_healpix_map())
 
@@ -488,28 +485,28 @@ class OperationsTestCase(unittest.TestCase):
             # and 2
             and_map_intersection = healsparse.and_intersection([sparse_map1, sparse_map2])
 
-            gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN))
-            hpmap_and_intersection = np.zeros_like(hpmap1) + hp.UNSEEN
+            gd, = np.where((hpmap1 > hpg.UNSEEN) & (hpmap2 > hpg.UNSEEN))
+            hpmap_and_intersection = np.zeros_like(hpmap1) + hpg.UNSEEN
             hpmap_and_intersection[gd] = hpmap1[gd].astype(dtype) & hpmap2[gd].astype(dtype)
             if dtype == np.uint64:
                 # For uint, we cannot tell the difference between 0 and UNSEEN
                 bd, = np.where(hpmap_and_intersection == 0)
-                hpmap_and_intersection[bd] = hp.UNSEEN
+                hpmap_and_intersection[bd] = hpg.UNSEEN
 
             testing.assert_almost_equal(hpmap_and_intersection, and_map_intersection.generate_healpix_map())
 
             # and 3
             and_map_intersection = healsparse.and_intersection([sparse_map1, sparse_map2, sparse_map3])
 
-            gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN) & (hpmap3 > hp.UNSEEN))
-            hpmap_and_intersection = np.zeros_like(hpmap1) + hp.UNSEEN
+            gd, = np.where((hpmap1 > hpg.UNSEEN) & (hpmap2 > hpg.UNSEEN) & (hpmap3 > hpg.UNSEEN))
+            hpmap_and_intersection = np.zeros_like(hpmap1) + hpg.UNSEEN
             hpmap_and_intersection[gd] = (hpmap1[gd].astype(dtype) &
                                           hpmap2[gd].astype(dtype) &
                                           hpmap3[gd].astype(dtype))
             if dtype == np.uint64:
                 # For uint, we cannot tell the difference between 0 and UNSEEN
                 bd, = np.where(hpmap_and_intersection == 0)
-                hpmap_and_intersection[bd] = hp.UNSEEN
+                hpmap_and_intersection[bd] = hpg.UNSEEN
 
             testing.assert_almost_equal(hpmap_and_intersection, and_map_intersection.generate_healpix_map())
 
@@ -518,43 +515,43 @@ class OperationsTestCase(unittest.TestCase):
             # and 2
             and_map_union = healsparse.and_union([sparse_map1, sparse_map2])
 
-            gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN))
-            hpmap_and_union = np.zeros_like(hpmap1) + hp.UNSEEN
+            gd, = np.where((hpmap1 > hpg.UNSEEN) | (hpmap2 > hpg.UNSEEN))
+            hpmap_and_union = np.zeros_like(hpmap1) + hpg.UNSEEN
 
             hpmap_and_union[gd] = -1.0
-            gd1, = np.where(hpmap1[gd] > hp.UNSEEN)
+            gd1, = np.where(hpmap1[gd] > hpg.UNSEEN)
             hpmap_and_union[gd[gd1]] = (hpmap_and_union[gd[gd1]].astype(np.int64) &
                                         hpmap1[gd[gd1]].astype(np.int64))
-            gd2, = np.where(hpmap2[gd] > hp.UNSEEN)
+            gd2, = np.where(hpmap2[gd] > hpg.UNSEEN)
             hpmap_and_union[gd[gd2]] = (hpmap_and_union[gd[gd2]].astype(np.int64) &
                                         hpmap2[gd[gd2]].astype(np.int64))
             if dtype == np.uint64:
                 # For uint, we cannot tell the difference between 0 and UNSEEN
                 bd, = np.where(hpmap_and_union == 0)
-                hpmap_and_union[bd] = hp.UNSEEN
+                hpmap_and_union[bd] = hpg.UNSEEN
 
             testing.assert_almost_equal(hpmap_and_union, and_map_union.generate_healpix_map())
 
             # and 3
             and_map_union = healsparse.and_union([sparse_map1, sparse_map2, sparse_map3])
 
-            gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN) | (hpmap3 > hp.UNSEEN))
-            hpmap_and_union = np.zeros_like(hpmap1) + hp.UNSEEN
+            gd, = np.where((hpmap1 > hpg.UNSEEN) | (hpmap2 > hpg.UNSEEN) | (hpmap3 > hpg.UNSEEN))
+            hpmap_and_union = np.zeros_like(hpmap1) + hpg.UNSEEN
 
             hpmap_and_union[gd] = -1.0
-            gd1, = np.where(hpmap1[gd] > hp.UNSEEN)
+            gd1, = np.where(hpmap1[gd] > hpg.UNSEEN)
             hpmap_and_union[gd[gd1]] = (hpmap_and_union[gd[gd1]].astype(np.int64) &
                                         hpmap1[gd[gd1]].astype(np.int64))
-            gd2, = np.where(hpmap2[gd] > hp.UNSEEN)
+            gd2, = np.where(hpmap2[gd] > hpg.UNSEEN)
             hpmap_and_union[gd[gd2]] = (hpmap_and_union[gd[gd2]].astype(np.int64) &
                                         hpmap2[gd[gd2]].astype(np.int64))
-            gd3, = np.where(hpmap3[gd] > hp.UNSEEN)
+            gd3, = np.where(hpmap3[gd] > hpg.UNSEEN)
             hpmap_and_union[gd[gd3]] = (hpmap_and_union[gd[gd3]].astype(np.int64) &
                                         hpmap3[gd[gd3]].astype(np.int64))
             if dtype == np.uint64:
                 # For uint, we cannot tell the difference between 0 and UNSEEN
                 bd, = np.where(hpmap_and_union == 0)
-                hpmap_and_union[bd] = hp.UNSEEN
+                hpmap_and_union[bd] = hpg.UNSEEN
 
             testing.assert_almost_equal(hpmap_and_union, and_map_union.generate_healpix_map())
 
@@ -562,13 +559,13 @@ class OperationsTestCase(unittest.TestCase):
 
             and_map = sparse_map1 & 2
 
-            hpmap_and2 = np.zeros_like(hpmap1) + hp.UNSEEN
-            gd, = np.where(hpmap1 > hp.UNSEEN)
+            hpmap_and2 = np.zeros_like(hpmap1) + hpg.UNSEEN
+            gd, = np.where(hpmap1 > hpg.UNSEEN)
             hpmap_and2[gd] = hpmap1[gd].astype(dtype) & 2
             if dtype == np.uint64:
                 # For uint, we cannot tell the difference between 0 and UNSEEN
                 bd, = np.where(hpmap_and2 == 0)
-                hpmap_and2[bd] = hp.UNSEEN
+                hpmap_and2[bd] = hpg.UNSEEN
 
             testing.assert_almost_equal(hpmap_and2, and_map.generate_healpix_map())
 
@@ -613,8 +610,8 @@ class OperationsTestCase(unittest.TestCase):
             # xor 2
             xor_map_intersection = healsparse.xor_intersection([sparse_map1, sparse_map2])
 
-            gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN))
-            hpmap_xor_intersection = np.zeros_like(hpmap1) + hp.UNSEEN
+            gd, = np.where((hpmap1 > hpg.UNSEEN) & (hpmap2 > hpg.UNSEEN))
+            hpmap_xor_intersection = np.zeros_like(hpmap1) + hpg.UNSEEN
             hpmap_xor_intersection[gd] = hpmap1[gd].astype(np.int64) ^ hpmap2[gd].astype(np.int64)
 
             testing.assert_almost_equal(hpmap_xor_intersection, xor_map_intersection.generate_healpix_map())
@@ -622,8 +619,8 @@ class OperationsTestCase(unittest.TestCase):
             # xor 3
             xor_map_intersection = healsparse.xor_intersection([sparse_map1, sparse_map2, sparse_map3])
 
-            gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN) & (hpmap3 > hp.UNSEEN))
-            hpmap_xor_intersection = np.zeros_like(hpmap1) + hp.UNSEEN
+            gd, = np.where((hpmap1 > hpg.UNSEEN) & (hpmap2 > hpg.UNSEEN) & (hpmap3 > hpg.UNSEEN))
+            hpmap_xor_intersection = np.zeros_like(hpmap1) + hpg.UNSEEN
             hpmap_xor_intersection[gd] = (hpmap1[gd].astype(np.int64) ^
                                           hpmap2[gd].astype(np.int64) ^
                                           hpmap3[gd].astype(np.int64))
@@ -635,14 +632,14 @@ class OperationsTestCase(unittest.TestCase):
             # xor 2
             xor_map_union = healsparse.xor_union([sparse_map1, sparse_map2])
 
-            gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN))
-            hpmap_xor_union = np.zeros_like(hpmap1) + hp.UNSEEN
+            gd, = np.where((hpmap1 > hpg.UNSEEN) | (hpmap2 > hpg.UNSEEN))
+            hpmap_xor_union = np.zeros_like(hpmap1) + hpg.UNSEEN
 
             hpmap_xor_union[gd] = 0.0
-            gd1, = np.where(hpmap1[gd] > hp.UNSEEN)
+            gd1, = np.where(hpmap1[gd] > hpg.UNSEEN)
             hpmap_xor_union[gd[gd1]] = (hpmap_xor_union[gd[gd1]].astype(np.int64) ^
                                         hpmap1[gd[gd1]].astype(np.int64))
-            gd2, = np.where(hpmap2[gd] > hp.UNSEEN)
+            gd2, = np.where(hpmap2[gd] > hpg.UNSEEN)
             hpmap_xor_union[gd[gd2]] = (hpmap_xor_union[gd[gd2]].astype(np.int64) ^
                                         hpmap2[gd[gd2]].astype(np.int64))
 
@@ -651,17 +648,17 @@ class OperationsTestCase(unittest.TestCase):
             # xor 3
             xor_map_union = healsparse.xor_union([sparse_map1, sparse_map2, sparse_map3])
 
-            gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN) | (hpmap3 > hp.UNSEEN))
-            hpmap_xor_union = np.zeros_like(hpmap1) + hp.UNSEEN
+            gd, = np.where((hpmap1 > hpg.UNSEEN) | (hpmap2 > hpg.UNSEEN) | (hpmap3 > hpg.UNSEEN))
+            hpmap_xor_union = np.zeros_like(hpmap1) + hpg.UNSEEN
 
             hpmap_xor_union[gd] = 0.0
-            gd1, = np.where(hpmap1[gd] > hp.UNSEEN)
+            gd1, = np.where(hpmap1[gd] > hpg.UNSEEN)
             hpmap_xor_union[gd[gd1]] = (hpmap_xor_union[gd[gd1]].astype(np.int64) ^
                                         hpmap1[gd[gd1]].astype(np.int64))
-            gd2, = np.where(hpmap2[gd] > hp.UNSEEN)
+            gd2, = np.where(hpmap2[gd] > hpg.UNSEEN)
             hpmap_xor_union[gd[gd2]] = (hpmap_xor_union[gd[gd2]].astype(np.int64) ^
                                         hpmap2[gd[gd2]].astype(np.int64))
-            gd3, = np.where(hpmap3[gd] > hp.UNSEEN)
+            gd3, = np.where(hpmap3[gd] > hpg.UNSEEN)
             hpmap_xor_union[gd[gd3]] = (hpmap_xor_union[gd[gd3]].astype(np.int64) ^
                                         hpmap3[gd[gd3]].astype(np.int64))
 
@@ -671,8 +668,8 @@ class OperationsTestCase(unittest.TestCase):
 
             xor_map = sparse_map1 ^ 2
 
-            hpmap_xor2 = np.zeros_like(hpmap1) + hp.UNSEEN
-            gd, = np.where(hpmap1 > hp.UNSEEN)
+            hpmap_xor2 = np.zeros_like(hpmap1) + hpg.UNSEEN
+            gd, = np.where(hpmap1 > hpg.UNSEEN)
             hpmap_xor2[gd] = hpmap1[gd].astype(np.int64) ^ 2
             testing.assert_almost_equal(hpmap_xor2, xor_map.generate_healpix_map())
 
@@ -701,8 +698,8 @@ class OperationsTestCase(unittest.TestCase):
         # subtraction
         test_map = sparse_map1 - 2.0
 
-        hpmap_test = np.zeros_like(hpmap1) + hp.UNSEEN
-        gd, = np.where(hpmap1 > hp.UNSEEN)
+        hpmap_test = np.zeros_like(hpmap1) + hpg.UNSEEN
+        gd, = np.where(hpmap1 > hpg.UNSEEN)
         hpmap_test[gd] = hpmap1[gd] - 2.0
 
         testing.assert_almost_equal(hpmap_test, test_map.generate_healpix_map())
@@ -714,8 +711,8 @@ class OperationsTestCase(unittest.TestCase):
         # division
         test_map = sparse_map1 / 2.0
 
-        hpmap_test = np.zeros_like(hpmap1) + hp.UNSEEN
-        gd, = np.where(hpmap1 > hp.UNSEEN)
+        hpmap_test = np.zeros_like(hpmap1) + hpg.UNSEEN
+        gd, = np.where(hpmap1 > hpg.UNSEEN)
         hpmap_test[gd] = hpmap1[gd] / 2.0
 
         testing.assert_almost_equal(hpmap_test, test_map.generate_healpix_map())
@@ -727,8 +724,8 @@ class OperationsTestCase(unittest.TestCase):
         # power
         test_map = sparse_map1 ** 2.0
 
-        hpmap_test = np.zeros_like(hpmap1) + hp.UNSEEN
-        gd, = np.where(hpmap1 > hp.UNSEEN)
+        hpmap_test = np.zeros_like(hpmap1) + hpg.UNSEEN
+        gd, = np.where(hpmap1 > hpg.UNSEEN)
         hpmap_test[gd] = hpmap1[gd] ** 2.0
 
         testing.assert_almost_equal(hpmap_test, test_map.generate_healpix_map())
@@ -771,16 +768,16 @@ class OperationsTestCase(unittest.TestCase):
         # Maximum of 2
         max_map = healsparse.max_intersection([sparse_map1, sparse_map2])
 
-        gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN))
-        hpmap_max = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where((hpmap1 > hpg.UNSEEN) & (hpmap2 > hpg.UNSEEN))
+        hpmap_max = np.zeros_like(hpmap1) + hpg.UNSEEN
         hpmap_max[gd] = np.fmax(hpmap1[gd], hpmap2[gd])
 
         testing.assert_almost_equal(hpmap_max, max_map.generate_healpix_map())
 
         # Maximum of 3
         max_map = healsparse.max_intersection([sparse_map1, sparse_map2, sparse_map3])
-        gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN) & (hpmap3 > hp.UNSEEN))
-        hpmap_max = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where((hpmap1 > hpg.UNSEEN) & (hpmap2 > hpg.UNSEEN) & (hpmap3 > hpg.UNSEEN))
+        hpmap_max = np.zeros_like(hpmap1) + hpg.UNSEEN
         hpmap_max[gd] = np.fmax(hpmap1[gd], hpmap2[gd])
         hpmap_max[gd] = np.fmax(hpmap_max[gd], hpmap3[gd])
 
@@ -820,16 +817,16 @@ class OperationsTestCase(unittest.TestCase):
         # Minimum of 2
         min_map = healsparse.min_intersection([sparse_map1, sparse_map2])
 
-        gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN))
-        hpmap_min = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where((hpmap1 > hpg.UNSEEN) & (hpmap2 > hpg.UNSEEN))
+        hpmap_min = np.zeros_like(hpmap1) + hpg.UNSEEN
         hpmap_min[gd] = np.fmin(hpmap1[gd], hpmap2[gd])
 
         testing.assert_almost_equal(hpmap_min, min_map.generate_healpix_map())
 
         # Minimum of 3 intersection
         min_map = healsparse.min_intersection([sparse_map1, sparse_map2, sparse_map3])
-        gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN) & (hpmap3 > hp.UNSEEN))
-        hpmap_min = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where((hpmap1 > hpg.UNSEEN) & (hpmap2 > hpg.UNSEEN) & (hpmap3 > hpg.UNSEEN))
+        hpmap_min = np.zeros_like(hpmap1) + hpg.UNSEEN
         hpmap_min[gd] = np.fmin(hpmap1[gd], hpmap2[gd])
         hpmap_min[gd] = np.fmin(hpmap_min[gd], hpmap3[gd])
         testing.assert_almost_equal(hpmap_min, min_map.generate_healpix_map())
@@ -868,16 +865,16 @@ class OperationsTestCase(unittest.TestCase):
         # Maximum of 2 map union
         max_map = healsparse.max_union([sparse_map1, sparse_map2])
 
-        gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN))
-        hpmap_max = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where((hpmap1 > hpg.UNSEEN) | (hpmap2 > hpg.UNSEEN))
+        hpmap_max = np.zeros_like(hpmap1) + hpg.UNSEEN
         hpmap_max[gd] = np.fmax(hpmap1[gd], hpmap2[gd])
 
         testing.assert_almost_equal(hpmap_max, max_map.generate_healpix_map())
 
         # Maximum of 3 map union
         max_map = healsparse.max_union([sparse_map1, sparse_map2, sparse_map3])
-        gd, = np.where((hpmap1 > hp.UNSEEN) | (hpmap2 > hp.UNSEEN) | (hpmap3 > hp.UNSEEN))
-        hpmap_max = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where((hpmap1 > hpg.UNSEEN) | (hpmap2 > hpg.UNSEEN) | (hpmap3 > hpg.UNSEEN))
+        hpmap_max = np.zeros_like(hpmap1) + hpg.UNSEEN
         hpmap_max[gd] = np.fmax(hpmap1[gd], hpmap2[gd])
         hpmap_max[gd] = np.fmax(hpmap_max[gd], hpmap3[gd])
 
@@ -917,21 +914,21 @@ class OperationsTestCase(unittest.TestCase):
         # Minimum of the union 2
         min_map = healsparse.min_union([sparse_map1, sparse_map2])
         # This is tricky because UNSEEN it's a float
-        hpmap1[hpmap1 == hp.UNSEEN] = -hp.UNSEEN
-        hpmap2[hpmap2 == hp.UNSEEN] = -hp.UNSEEN
-        gd, = np.where((hpmap1 < -hp.UNSEEN) | (hpmap2 < -hp.UNSEEN))
-        hpmap_min = np.zeros_like(hpmap1) + hp.UNSEEN
+        hpmap1[hpmap1 == hpg.UNSEEN] = -hpg.UNSEEN
+        hpmap2[hpmap2 == hpg.UNSEEN] = -hpg.UNSEEN
+        gd, = np.where((hpmap1 < -hpg.UNSEEN) | (hpmap2 < -hpg.UNSEEN))
+        hpmap_min = np.zeros_like(hpmap1) + hpg.UNSEEN
         hpmap_min[gd] = np.fmin(hpmap1[gd], hpmap2[gd])  # This would be the intersection
 
         testing.assert_almost_equal(hpmap_min, min_map.generate_healpix_map())
 
         # Maximum of 3
         min_map = healsparse.min_union([sparse_map1, sparse_map2, sparse_map3])
-        hpmap1[hpmap1 == hp.UNSEEN] = -hp.UNSEEN
-        hpmap2[hpmap2 == hp.UNSEEN] = -hp.UNSEEN
-        hpmap3[hpmap3 == hp.UNSEEN] = -hp.UNSEEN
-        gd, = np.where((hpmap1 < -hp.UNSEEN) | (hpmap2 < -hp.UNSEEN) | (hpmap3 < -hp.UNSEEN))
-        hpmap_min = np.zeros_like(hpmap1) + hp.UNSEEN
+        hpmap1[hpmap1 == hpg.UNSEEN] = -hpg.UNSEEN
+        hpmap2[hpmap2 == hpg.UNSEEN] = -hpg.UNSEEN
+        hpmap3[hpmap3 == hpg.UNSEEN] = -hpg.UNSEEN
+        gd, = np.where((hpmap1 < -hpg.UNSEEN) | (hpmap2 < -hpg.UNSEEN) | (hpmap3 < -hpg.UNSEEN))
+        hpmap_min = np.zeros_like(hpmap1) + hpg.UNSEEN
         hpmap_min[gd] = np.fmin(hpmap1[gd], hpmap2[gd])
         hpmap_min[gd] = np.fmin(hpmap_min[gd], hpmap3[gd])
 
@@ -971,8 +968,8 @@ class OperationsTestCase(unittest.TestCase):
         # Test an example ufunc (np.add) with 2 maps
 
         add_map = healsparse.ufunc_intersection([sparse_map1, sparse_map2], np.add)
-        gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN))
-        hpmap_add = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where((hpmap1 > hpg.UNSEEN) & (hpmap2 > hpg.UNSEEN))
+        hpmap_add = np.zeros_like(hpmap1) + hpg.UNSEEN
         hpmap_add[gd] = np.add(hpmap1[gd], hpmap2[gd])
 
         testing.assert_almost_equal(hpmap_add, add_map.generate_healpix_map())
@@ -980,8 +977,8 @@ class OperationsTestCase(unittest.TestCase):
         # Test an example ufunc (np.add) with 3 maps
 
         add_map = healsparse.ufunc_intersection([sparse_map1, sparse_map2, sparse_map3], np.add)
-        gd, = np.where((hpmap1 > hp.UNSEEN) & (hpmap2 > hp.UNSEEN) & (hpmap3 > hp.UNSEEN))
-        hpmap_add = np.zeros_like(hpmap1) + hp.UNSEEN
+        gd, = np.where((hpmap1 > hpg.UNSEEN) & (hpmap2 > hpg.UNSEEN) & (hpmap3 > hpg.UNSEEN))
+        hpmap_add = np.zeros_like(hpmap1) + hpg.UNSEEN
         hpmap_add[gd] = np.add(hpmap1[gd], hpmap2[gd])
         hpmap_add[gd] = np.add(hpmap_add[gd], hpmap3[gd])
         testing.assert_almost_equal(hpmap_add, add_map.generate_healpix_map())
@@ -1020,21 +1017,21 @@ class OperationsTestCase(unittest.TestCase):
         # Test an example ufunc (np.add) with 2 maps
 
         add_map = healsparse.ufunc_union([sparse_map1, sparse_map2], np.add)
-        # This is tricky again because hp.UNSEEN is a float
-        mask = (hpmap1 == hp.UNSEEN) & (hpmap2 == hp.UNSEEN)
-        hpmap1[hpmap1 == hp.UNSEEN] = 0
-        hpmap2[hpmap2 == hp.UNSEEN] = 0
+        # This is tricky again because hpg.UNSEEN is a float
+        mask = (hpmap1 == hpg.UNSEEN) & (hpmap2 == hpg.UNSEEN)
+        hpmap1[hpmap1 == hpg.UNSEEN] = 0
+        hpmap2[hpmap2 == hpg.UNSEEN] = 0
         hpmap_add = np.add(hpmap1, hpmap2)
-        hpmap_add[mask] = hp.UNSEEN
+        hpmap_add[mask] = hpg.UNSEEN
         testing.assert_almost_equal(hpmap_add, add_map.generate_healpix_map())
 
         # Test an example ufunc (np.add) with 3 maps
         hpmap_add[mask] = 0
         add_map = healsparse.ufunc_union([sparse_map1, sparse_map2, sparse_map3], np.add)
-        mask2 = (mask) & (hpmap3 == hp.UNSEEN)
-        hpmap3[hpmap3 == hp.UNSEEN] = 0
+        mask2 = (mask) & (hpmap3 == hpg.UNSEEN)
+        hpmap3[hpmap3 == hpg.UNSEEN] = 0
         hpmap_add = np.add(hpmap_add, hpmap3)
-        hpmap_add[mask2] = hp.UNSEEN
+        hpmap_add[mask2] = hpg.UNSEEN
         testing.assert_almost_equal(hpmap_add, add_map.generate_healpix_map())
 
 

--- a/tests/test_randoms.py
+++ b/tests/test_randoms.py
@@ -1,8 +1,6 @@
-from __future__ import division, absolute_import, print_function
-
 import unittest
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 
 import healsparse
 
@@ -20,9 +18,7 @@ class UniformRandomTestCase(unittest.TestCase):
 
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, dtype=np.float32)
 
-        theta, phi = hp.pix2ang(nside_map, np.arange(hp.nside2npix(nside_map)), nest=True)
-        ra = np.degrees(phi)
-        dec = 90.0 - np.degrees(theta)
+        ra, dec = hpg.pixel_to_angle(nside_map, np.arange(hpg.nside_to_npixel(nside_map)))
         # Arbitrarily chosen range
         gd_pix, = np.where((ra > 100.0) & (ra < 180.0) & (dec > 5.0) & (dec < 30.0))
         sparse_map.update_values_pix(gd_pix, np.zeros(gd_pix.size, dtype=np.float32))
@@ -41,7 +37,7 @@ class UniformRandomTestCase(unittest.TestCase):
         self.assertTrue(dec_rand.max() < (30.0 + 0.5))
 
         # And these are all in the map
-        self.assertTrue(np.all(sparse_map.get_values_pos(ra_rand, dec_rand, lonlat=True) > hp.UNSEEN))
+        self.assertTrue(np.all(sparse_map.get_values_pos(ra_rand, dec_rand, lonlat=True) > hpg.UNSEEN))
 
     def test_uniform_randoms_cross_ra0(self):
         """
@@ -55,9 +51,7 @@ class UniformRandomTestCase(unittest.TestCase):
 
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, dtype=np.float32)
 
-        theta, phi = hp.pix2ang(nside_map, np.arange(hp.nside2npix(nside_map)), nest=True)
-        ra = np.degrees(phi)
-        dec = 90.0 - np.degrees(theta)
+        ra, dec = hpg.pixel_to_angle(nside_map, np.arange(hpg.nside_to_npixel(nside_map)))
         # Arbitrarily chosen range
         gd_pix, = np.where(((ra > 300.0) | (ra < 80.0)) & (dec > -20.0) & (dec < -5.0))
         sparse_map.update_values_pix(gd_pix, np.zeros(gd_pix.size, dtype=np.float32))
@@ -74,7 +68,7 @@ class UniformRandomTestCase(unittest.TestCase):
         self.assertTrue(dec_rand.max() < (-5.0 + 0.5))
 
         # And these are all in the map
-        self.assertTrue(np.all(sparse_map.get_values_pos(ra_rand, dec_rand, lonlat=True) > hp.UNSEEN))
+        self.assertTrue(np.all(sparse_map.get_values_pos(ra_rand, dec_rand, lonlat=True) > hpg.UNSEEN))
 
     def test_uniform_randoms_fast(self):
         """
@@ -88,9 +82,7 @@ class UniformRandomTestCase(unittest.TestCase):
 
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, dtype=np.float32)
 
-        theta, phi = hp.pix2ang(nside_map, np.arange(hp.nside2npix(nside_map)), nest=True)
-        ra = np.degrees(phi)
-        dec = 90.0 - np.degrees(theta)
+        ra, dec = hpg.pixel_to_angle(nside_map, np.arange(hpg.nside_to_npixel(nside_map)))
         # Arbitrarily chosen range
         gd_pix, = np.where((ra > 100.0) & (ra < 180.0) & (dec > 5.0) & (dec < 30.0))
         sparse_map.update_values_pix(gd_pix, np.zeros(gd_pix.size, dtype=np.float32))
@@ -109,7 +101,7 @@ class UniformRandomTestCase(unittest.TestCase):
         self.assertTrue(dec_rand.max() < (30.0 + 0.5))
 
         # And these are all in the map
-        self.assertTrue(np.all(sparse_map.get_values_pos(ra_rand, dec_rand, lonlat=True) > hp.UNSEEN))
+        self.assertTrue(np.all(sparse_map.get_values_pos(ra_rand, dec_rand, lonlat=True) > hpg.UNSEEN))
 
 
 if __name__ == '__main__':

--- a/tests/test_recarray.py
+++ b/tests/test_recarray.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy.testing as testing
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 from numpy import random
 import tempfile
 import shutil
@@ -39,13 +39,12 @@ class RecArrayTestCase(unittest.TestCase):
         sparse_map.write(fname)
 
         # Make the test values
-        hpmapCol1 = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
-        hpmapCol2 = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        hpmapCol1 = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
+        hpmapCol2 = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         hpmapCol1[pixel] = values['col1']
         hpmapCol2[pixel] = values['col2']
-        theta = np.radians(90.0 - dec)
-        phi = np.radians(ra)
-        ipnest_test = hp.ang2pix(nside_map, theta, phi, nest=True)
+
+        ipnest_test = hpg.angle_to_pixel(nside_map, ra, dec)
 
         # Read in the map
         sparse_map = healsparse.HealSparseMap.read(fname)
@@ -72,10 +71,10 @@ class RecArrayTestCase(unittest.TestCase):
         outside_small, = np.where(ipnest_cov > 1)
         # column1 is the "primary" column and will return UNSEEN
         test_values1b = hpmapCol1[ipnest_test].copy()
-        test_values1b[outside_small] = hp.UNSEEN
+        test_values1b[outside_small] = hpg.UNSEEN
         # column2 is not the primary column and will also return UNSEEN
         test_values2b = hpmapCol2[ipnest_test].copy()
-        test_values2b[outside_small] = hp.UNSEEN
+        test_values2b[outside_small] = hpg.UNSEEN
 
         testing.assert_almost_equal(sparse_map_small.get_values_pix(ipnest_test)['col1'], test_values1b)
         testing.assert_almost_equal(sparse_map_small.get_values_pix(ipnest_test)['col2'], test_values2b)
@@ -116,13 +115,11 @@ class RecArrayTestCase(unittest.TestCase):
         sparse_map = healsparse.HealSparseMap.read(fname)
 
         # Test some values
-        theta = np.radians(90.0 - dec)
-        phi = np.radians(ra)
-        ipnest = hp.ang2pix(nside_map, theta, phi)
-        test_map_col1 = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        ipnest = hpg.angle_to_pixel(nside_map, ra, dec)
+        test_map_col1 = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         test_map_col1[pixel] = values['col1']
         test_map_col1[pixel2] = values2['col1']
-        test_map_col2 = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        test_map_col2 = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         test_map_col2[pixel] = values['col2']
         test_map_col2[pixel2] = values2['col2']
 
@@ -136,8 +133,8 @@ class RecArrayTestCase(unittest.TestCase):
         test_values_small_col1 = test_map_col1[ipnest]
         test_values_small_col2 = test_map_col2[ipnest]
         outside_small, = np.where((ipnest_cov != 0) & (ipnest_cov != 1) & (ipnest_cov != 3179))
-        test_values_small_col1[outside_small] = hp.UNSEEN
-        test_values_small_col2[outside_small] = hp.UNSEEN
+        test_values_small_col1[outside_small] = hpg.UNSEEN
+        test_values_small_col2[outside_small] = hpg.UNSEEN
 
         testing.assert_almost_equal(sparse_map_small.get_values_pix(ipnest)['col1'],
                                     test_values_small_col1)
@@ -172,13 +169,11 @@ class RecArrayTestCase(unittest.TestCase):
         sparse_map.write(fname, format='parquet')
 
         # Make the test values
-        hpmapCol1 = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
-        hpmapCol2 = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        hpmapCol1 = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
+        hpmapCol2 = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         hpmapCol1[pixel] = values['col1']
         hpmapCol2[pixel] = values['col2']
-        theta = np.radians(90.0 - dec)
-        phi = np.radians(ra)
-        ipnest_test = hp.ang2pix(nside_map, theta, phi, nest=True)
+        ipnest_test = hpg.angle_to_pixel(nside_map, ra, dec)
 
         # Read in the map
         sparse_map = healsparse.HealSparseMap.read(fname)
@@ -204,10 +199,10 @@ class RecArrayTestCase(unittest.TestCase):
         outside_small, = np.where(ipnest_cov > 1)
         # column1 is the "primary" column and will return UNSEEN
         test_values1b = hpmapCol1[ipnest_test].copy()
-        test_values1b[outside_small] = hp.UNSEEN
+        test_values1b[outside_small] = hpg.UNSEEN
         # column2 is not the primary column and will also return UNSEEN
         test_values2b = hpmapCol2[ipnest_test].copy()
-        test_values2b[outside_small] = hp.UNSEEN
+        test_values2b[outside_small] = hpg.UNSEEN
 
         testing.assert_almost_equal(sparse_map_small.get_values_pix(ipnest_test)['col1'], test_values1b)
         testing.assert_almost_equal(sparse_map_small.get_values_pix(ipnest_test)['col2'], test_values2b)
@@ -249,13 +244,11 @@ class RecArrayTestCase(unittest.TestCase):
         sparse_map = healsparse.HealSparseMap.read(fname)
 
         # Test some values
-        theta = np.radians(90.0 - dec)
-        phi = np.radians(ra)
-        ipnest = hp.ang2pix(nside_map, theta, phi)
-        test_map_col1 = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        ipnest = hpg.angle_to_pixel(nside_map, ra, dec)
+        test_map_col1 = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         test_map_col1[pixel] = values['col1']
         test_map_col1[pixel2] = values2['col1']
-        test_map_col2 = np.zeros(hp.nside2npix(nside_map)) + hp.UNSEEN
+        test_map_col2 = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         test_map_col2[pixel] = values['col2']
         test_map_col2[pixel2] = values2['col2']
 
@@ -269,8 +262,8 @@ class RecArrayTestCase(unittest.TestCase):
         test_values_small_col1 = test_map_col1[ipnest]
         test_values_small_col2 = test_map_col2[ipnest]
         outside_small, = np.where((ipnest_cov != 0) & (ipnest_cov != 1) & (ipnest_cov != 3179))
-        test_values_small_col1[outside_small] = hp.UNSEEN
-        test_values_small_col2[outside_small] = hp.UNSEEN
+        test_values_small_col1[outside_small] = hpg.UNSEEN
+        test_values_small_col2[outside_small] = hpg.UNSEEN
 
         testing.assert_almost_equal(sparse_map_small.get_values_pix(ipnest)['col1'],
                                     test_values_small_col1)

--- a/tests/test_single_datatypes.py
+++ b/tests/test_single_datatypes.py
@@ -1,8 +1,6 @@
-from __future__ import division, absolute_import, print_function
-
 import unittest
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 
 import healsparse
 
@@ -44,13 +42,13 @@ class SingleDatatypesTestCase(unittest.TestCase):
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, np.float32)
 
         self.assertEqual(sparse_map.dtype, np.float32)
-        self.assertEqual(sparse_map._sentinel, hp.UNSEEN)
+        self.assertEqual(sparse_map._sentinel, hpg.UNSEEN)
 
         # int64
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, np.float64)
 
         self.assertEqual(sparse_map.dtype, np.float64)
-        self.assertEqual(sparse_map._sentinel, hp.UNSEEN)
+        self.assertEqual(sparse_map._sentinel, hpg.UNSEEN)
 
     def test_datatypes_uints(self):
         """

--- a/tests/test_update_values.py
+++ b/tests/test_update_values.py
@@ -1,9 +1,7 @@
-from __future__ import division, absolute_import, print_function
-
 import unittest
 import numpy.testing as testing
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 import healsparse
 
 
@@ -178,14 +176,14 @@ class UpdateValuesTestCase(unittest.TestCase):
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, dtype)
 
         pixels = np.array([0, 1, 5, 10, 20])
-        ra, dec = hp.pix2ang(nside_map, pixels, lonlat=True, nest=True)
+        ra, dec = hpg.pixel_to_angle(nside_map, pixels)
 
         sparse_map.update_values_pos(ra, dec, 0.0)
         testing.assert_array_almost_equal(sparse_map[pixels], 0.0)
 
         # Test non-unique raise
         pixels = np.array([0, 1, 5, 10, 0])
-        ra, dec = hp.pix2ang(nside_map, pixels, lonlat=True, nest=True)
+        ra, dec = hpg.pixel_to_angle(nside_map, pixels)
         self.assertRaises(ValueError, sparse_map.update_values_pos, ra, dec, 0.0)
 
 

--- a/tests/test_validarea.py
+++ b/tests/test_validarea.py
@@ -1,9 +1,7 @@
-from __future__ import division, absolute_import, print_function
-
 import unittest
 import numpy.testing as testing
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 from numpy import random
 
 import healsparse
@@ -20,7 +18,7 @@ class ValidAreaTestCase(unittest.TestCase):
         nside_map = 64
 
         n_rand = 1000
-        r_indices = np.random.choice(np.arange(hp.nside2npix(nside_map)),
+        r_indices = np.random.choice(np.arange(hpg.nside_to_npixel(nside_map)),
                                      size=n_rand, replace=False)
 
         for dt in [np.float64, np.int64]:
@@ -32,6 +30,10 @@ class ValidAreaTestCase(unittest.TestCase):
 
             # Fill up the maps
             sparse_map.update_values_pix(r_indices, np.ones(n_rand, dtype=dt))
-            testing.assert_equal(sparse_map.get_valid_area(), n_rand*hp.nside2pixarea(nside_map,
-                                 degrees=True))
+            testing.assert_equal(sparse_map.get_valid_area(),
+                                 n_rand*hpg.nside_to_pixel_area(nside_map, degrees=True))
             testing.assert_equal(sparse_map.n_valid, n_rand)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_widemasks.py
+++ b/tests/test_widemasks.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy.testing as testing
 import numpy as np
-import healpy as hp
+import hpgeom as hpg
 from numpy import random
 import tempfile
 import os
@@ -46,7 +46,7 @@ class WideMasksTestCase(unittest.TestCase):
         testing.assert_array_equal(sparse_map.valid_pixels, pixel)
         testing.assert_equal(sparse_map.n_valid, len(pixel))
 
-        pospix = hp.ang2pix(nside_map, ra, dec, lonlat=True, nest=True)
+        pospix = hpg.angle_to_pixel(nside_map, ra, dec)
         inds = np.searchsorted(pixel, pospix)
         b, = np.where((inds > 0) & (inds < pixel.size))
         comp_arr = np.zeros(pospix.size, dtype=np.bool_)
@@ -157,7 +157,7 @@ class WideMasksTestCase(unittest.TestCase):
         testing.assert_array_equal(sparse_map_in.check_bits_pix(pixel, [7]), False)
         testing.assert_array_equal(sparse_map_in.check_bits_pix(pixel, [5, 7]), True)
 
-        pospix = hp.ang2pix(nside_map, ra, dec, lonlat=True, nest=True)
+        pospix = hpg.angle_to_pixel(nside_map, ra, dec)
         inds = np.searchsorted(pixel, pospix)
         b, = np.where((inds > 0) & (inds < pixel.size))
         comp_arr = np.zeros(pospix.size, dtype=np.bool_)
@@ -254,7 +254,7 @@ class WideMasksTestCase(unittest.TestCase):
         testing.assert_array_equal(sparse_map_in.check_bits_pix(pixel, [7]), False)
         testing.assert_array_equal(sparse_map_in.check_bits_pix(pixel, [5, 7]), True)
 
-        pospix = hp.ang2pix(nside_map, ra, dec, lonlat=True, nest=True)
+        pospix = hpg.angle_to_pixel(nside_map, ra, dec)
         inds = np.searchsorted(pixel, pospix)
         b, = np.where((inds > 0) & (inds < pixel.size))
         comp_arr = np.zeros(pospix.size, dtype=np.bool_)
@@ -378,7 +378,7 @@ class WideMasksTestCase(unittest.TestCase):
 
         or_map_intersection = healsparse.or_intersection([sparse_map1, sparse_map2])
 
-        all_pixels = np.arange(hp.nside2npix(nside_map))
+        all_pixels = np.arange(hpg.nside_to_npixel(nside_map))
         arr1 = sparse_map1.get_values_pix(all_pixels)
         arr2 = sparse_map2.get_values_pix(all_pixels)
         gd, = np.where((arr1.sum(axis=1) > 0) & (arr2.sum(axis=1) > 0))
@@ -421,7 +421,7 @@ class WideMasksTestCase(unittest.TestCase):
 
         and_map_intersection = healsparse.and_intersection([sparse_map1, sparse_map2])
 
-        all_pixels = np.arange(hp.nside2npix(nside_map))
+        all_pixels = np.arange(hpg.nside_to_npixel(nside_map))
         arr1 = sparse_map1.get_values_pix(all_pixels)
         arr2 = sparse_map2.get_values_pix(all_pixels)
         gd, = np.where((arr1.sum(axis=1) > 0) & (arr2.sum(axis=1) > 0))
@@ -472,7 +472,7 @@ class WideMasksTestCase(unittest.TestCase):
 
         xor_map_intersection = healsparse.xor_intersection([sparse_map1, sparse_map2])
 
-        all_pixels = np.arange(hp.nside2npix(nside_map))
+        all_pixels = np.arange(hpg.nside_to_npixel(nside_map))
         arr1 = sparse_map1.get_values_pix(all_pixels)
         arr2 = sparse_map2.get_values_pix(all_pixels)
         gd, = np.where((arr1.sum(axis=1) > 0) & (arr2.sum(axis=1) > 0))


### PR DESCRIPTION
This PR is a major change, replacing `healpy` as the healpix geometry backend with the much simpler `hpgeom`.  This will lead to faster import times, fewer spurious warnings, and the ability to add new shapes to the geometry library such as ellipses and boxes of constant ra/dec.

See https://hpgeom.readthedocs.io/en/latest/ for details on `hpgeom`.