### PR TITLE
Add "add" operation to update values, and divide operations for pixel intersections.

### DIFF
--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -43,7 +43,11 @@ Arithmetic operations with a constant are very simple, and are handled with the 
 Operations With Multiple Maps
 -----------------------------
 
-Operations between maps can be done with either "union" or "intersection" mode.  The basic operations supported are :code:`sum`, :code:`product`, :code:`min`, :code:`max`, :code:`or`, :code:`and`, :code:`xor`, and :code:`ufunc`.  Note that :code:`or`, :code:`and`:, and :code:`xor` operations are only supported for integer maps.  Note that operations between maps are only supported if they have the same :code:`nside_sparse` resolution and data type.  In all cases, the function name is :code:`operation_union()` or :code:`operation_intersection()`.  For example,
+Operations between maps can be done with either "union" or "intersection" mode.
+The basic operations supported are :code:`sum`, :code:`product`, :code:`divide`, :code:`floor_divide`, :code:`min`, :code:`max`, :code:`or`, :code:`and`, :code:`xor`, and :code:`ufunc`.  Note that :code:`or`, :code:`and`:, and :code:`xor` operations are only supported for integer maps.  Note that operations between maps are only supported if they have the same :code:`nside_sparse` resolution and data type.
+In all cases except division, the function name is :code:`operation_union()` or :code:`operation_intersection()`.
+The division routines only support intersection operations.
+For example,
 
 .. code-block :: python
 

--- a/healsparse/__init__.py
+++ b/healsparse/__init__.py
@@ -19,6 +19,7 @@ from .operations import and_union, and_intersection
 from .operations import xor_union, xor_intersection
 from .operations import max_intersection, min_intersection, max_union, min_union
 from .operations import ufunc_union, ufunc_intersection
+from .operations import divide_intersection, floor_divide_intersection
 from . import geom
 from .geom import Circle, Ellipse, Polygon, realize_geom
 from .utils import WIDE_MASK

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -410,22 +410,28 @@ class HealSparseMap(object):
         Parameters
         ----------
         ra_or_theta : `float`, array-like
-           Angular coordinates of points on a sphere.
+            Angular coordinates of points on a sphere.
         dec_or_phi : `float`, array-like
-           Angular coordinates of points on a sphere.
+            Angular coordinates of points on a sphere.
         values : `np.ndarray`
-           Value or Array of values.  Must be same type as sparse_map.
+            Value or Array of values.  Must be same type as sparse_map.
         lonlat : `bool`, optional
-           If True, input angles are longitude and latitude in degrees.
-           Otherwise, they are co-latitude and longitude in radians.
+            If True, input angles are longitude and latitude in degrees.
+            Otherwise, they are co-latitude and longitude in radians.
         operation : `str`, optional
-           Operation to use to update values.  May be 'replace' (default),
-           'or', or 'and' (for bit masks)
+            Operation to use to update values.  May be 'replace' (default);
+            'add'; 'or', or 'and' (for bit masks).
 
         Raises
         ------
-        ValueError : Raised if positions do not resolve to unique
-           positions and operation is 'replace'.
+        ValueError
+            If positions do not resolve to unique positions and operation
+            is 'replace'.
+
+        Notes
+        -----
+        During the 'add' operation, if the default sentinel map value is not
+        equal to 0, then any default values will be set to 0 prior to addition.
         """
         return self.update_values_pix(hpg.angle_to_pixel(self._nside_sparse,
                                                          ra_or_theta,
@@ -442,23 +448,33 @@ class HealSparseMap(object):
         Parameters
         ----------
         pixels : `np.ndarray`
-           Integer array of sparse_map pixel values
+            Integer array of sparse_map pixel values
         values : `np.ndarray`
-           Value or Array of values.  Must be same type as sparse_map.
+            Value or Array of values.  Must be same type as sparse_map.
         operation : `str`, optional
-           Operation to use to update values.  May be 'replace' (default),
-           'or', or 'and' (for bit masks)
+            Operation to use to update values.  May be 'replace' (default);
+            'add'; 'or', or 'and' (for bit masks).
 
         Raises
         ------
-        ValueError : Raised if positions do not resolve to unique
-           positions and operation is 'replace'.
+        ValueError
+            Raised if pixels are not unique and operation is 'replace', or if
+            operation is not 'replace' on a recarray map.
+
+        Notes
+        -----
+        During the 'add' operation, if the default sentinel map value is not
+        equal to 0, then any default values will be set to 0 prior to addition.
         """
         if operation != 'replace':
-            if operation != 'or' and operation != 'and':
-                raise ValueError("Only replace, or, and and are supported operations")
-            if not self.is_integer_map or self._sentinel != 0:
-                raise ValueError("Can only use and/or with integer map with 0 sentinel")
+            if operation in ['or', 'and']:
+                if not self.is_integer_map or self._sentinel != 0:
+                    raise ValueError("Can only use and/or with integer map with 0 sentinel")
+            elif operation == 'add':
+                if self._is_rec_array:
+                    raise ValueError("Cannot use 'add' operation with a recarray map.")
+            else:
+                raise ValueError("Only 'replace', 'add', 'or', and 'and' are supported operations")
 
         if operation == 'replace':
             # Check for unique pixel positions
@@ -539,28 +555,31 @@ class HealSparseMap(object):
         out_cov = ~cov_mask[ipnest_cov]
 
         # Replace values for those pixels in the coverage map
+        _indices = _pix[in_cov] + self._cov_map[ipnest_cov[in_cov]]
         if is_single_value:
             if operation == 'replace':
-                self._sparse_map[_pix[in_cov] + self._cov_map[ipnest_cov[in_cov]]] = _values[0]
+                self._sparse_map[_indices] = _values[0]
+            elif operation == 'add':
+                # Put in a check to reset uncovered pixels to 0
+                if self._sentinel != 0:
+                    self._sparse_map[_indices[self._sparse_map[_indices] != 0]] = 0
+                np.add.at(self._sparse_map, _indices, _values[0])
             elif operation == 'or':
-                np.bitwise_or.at(self._sparse_map,
-                                 _pix[in_cov] + self._cov_map[ipnest_cov[in_cov]],
-                                 _values[0])
+                np.bitwise_or.at(self._sparse_map, _indices, _values[0])
             elif operation == 'and':
-                np.bitwise_and.at(self._sparse_map,
-                                  _pix[in_cov] + self._cov_map[ipnest_cov[in_cov]],
-                                  _values[0])
+                np.bitwise_and.at(self._sparse_map, _indices, _values[0])
         else:
             if operation == 'replace':
-                self._sparse_map[_pix[in_cov] + self._cov_map[ipnest_cov[in_cov]]] = _values[in_cov]
+                self._sparse_map[_indices] = _values[in_cov]
+            elif operation == 'add':
+                # Put in a check to reset uncovered pixels to 0
+                if self._sentinel != 0:
+                    self._sparse_map[_indices[self._sparse_map[_indices] != 0]] = 0
+                np.add.at(self._sparse_map, _indices, _values[in_cov])
             elif operation == 'or':
-                np.bitwise_or.at(self._sparse_map,
-                                 _pix[in_cov] + self._cov_map[ipnest_cov[in_cov]],
-                                 _values[in_cov])
+                np.bitwise_or.at(self._sparse_map, _indices, _values[in_cov])
             elif operation == 'and':
-                np.bitwise_and.at(self._sparse_map,
-                                  _pix[in_cov] + self._cov_map[ipnest_cov[in_cov]],
-                                  _values[in_cov])
+                np.bitwise_and.at(self._sparse_map, _indices, _values[in_cov])
 
         # Update the coverage map for the rest of the pixels (if necessary)
         if out_cov.sum() > 0:
@@ -575,30 +594,31 @@ class HealSparseMap(object):
             oldsize = len(self._sparse_map)
             self._reserve_cov_pix(new_cov_pix)
 
+            _indices = _pix[out_cov] + self._cov_map[ipnest_cov[out_cov]] - oldsize
             if is_single_value:
                 if operation == 'replace':
-                    self._sparse_map[oldsize:][_pix[out_cov] + self._cov_map[ipnest_cov[out_cov]] -
-                                               oldsize] = _values[0]
+                    self._sparse_map[oldsize:][_indices] = _values[0]
+                elif operation == 'add':
+                    # Put in a check to reset uncovered pixels to 0
+                    if self._sentinel != 0:
+                        self._sparse_map[oldsize:][_indices[self._sparse_map[_indices] != 0]] = 0
+                    np.add.at(self._sparse_map[oldsize:], _indices, _values[0])
                 elif operation == 'or':
-                    np.bitwise_or.at(self._sparse_map[oldsize:],
-                                     _pix[out_cov] + self._cov_map[ipnest_cov[out_cov]] - oldsize,
-                                     _values[0])
+                    np.bitwise_or.at(self._sparse_map[oldsize:], _indices, _values[0])
                 elif operation == 'and':
-                    np.bitwise_and.at(self._sparse_map[oldsize:],
-                                      _pix[out_cov] + self._cov_map[ipnest_cov[out_cov]] - oldsize,
-                                      _values[0])
+                    np.bitwise_and.at(self._sparse_map[oldsize:], _indices, _values[0])
             else:
                 if operation == 'replace':
-                    self._sparse_map[oldsize:][_pix[out_cov] + self._cov_map[ipnest_cov[out_cov]] -
-                                               oldsize] = _values[out_cov]
+                    self._sparse_map[oldsize:][_indices] = _values[out_cov]
+                elif operation == 'add':
+                    # Put in a check to reset uncovered pixels to 0
+                    if self._sentinel != 0:
+                        self._sparse_map[oldsize:][_indices[self._sparse_map[_indices] != 0]] = 0
+                    np.add.at(self._sparse_map[oldsize:], _indices, _values[out_cov])
                 elif operation == 'or':
-                    np.bitwise_or.at(self._sparse_map[oldsize:],
-                                     _pix[out_cov] + self._cov_map[ipnest_cov[out_cov]] - oldsize,
-                                     _values[out_cov])
+                    np.bitwise_or.at(self._sparse_map[oldsize:], _indices, _values[out_cov])
                 elif operation == 'and':
-                    np.bitwise_and.at(self._sparse_map[oldsize:],
-                                      _pix[out_cov] + self._cov_map[ipnest_cov[out_cov]] - oldsize,
-                                      _values[out_cov])
+                    np.bitwise_and.at(self._sparse_map[oldsize:], _indices, _values[out_cov])
 
     def set_bits_pix(self, pixels, bits, nest=True):
         """

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -562,7 +562,7 @@ class HealSparseMap(object):
             elif operation == 'add':
                 # Put in a check to reset uncovered pixels to 0
                 if self._sentinel != 0:
-                    self._sparse_map[_indices[self._sparse_map[_indices] != 0]] = 0
+                    self._sparse_map[_indices[self._sparse_map[_indices] == self._sentinel]] = 0
                 np.add.at(self._sparse_map, _indices, _values[0])
             elif operation == 'or':
                 np.bitwise_or.at(self._sparse_map, _indices, _values[0])
@@ -574,7 +574,7 @@ class HealSparseMap(object):
             elif operation == 'add':
                 # Put in a check to reset uncovered pixels to 0
                 if self._sentinel != 0:
-                    self._sparse_map[_indices[self._sparse_map[_indices] != 0]] = 0
+                    self._sparse_map[_indices[self._sparse_map[_indices] == self._sentinel]] = 0
                 np.add.at(self._sparse_map, _indices, _values[in_cov])
             elif operation == 'or':
                 np.bitwise_or.at(self._sparse_map, _indices, _values[in_cov])
@@ -601,7 +601,7 @@ class HealSparseMap(object):
                 elif operation == 'add':
                     # Put in a check to reset uncovered pixels to 0
                     if self._sentinel != 0:
-                        self._sparse_map[oldsize:][_indices[self._sparse_map[_indices] != 0]] = 0
+                        self._sparse_map[oldsize:][_indices[self._sparse_map[_indices] == self._sentinel]] = 0
                     np.add.at(self._sparse_map[oldsize:], _indices, _values[0])
                 elif operation == 'or':
                     np.bitwise_or.at(self._sparse_map[oldsize:], _indices, _values[0])
@@ -613,7 +613,7 @@ class HealSparseMap(object):
                 elif operation == 'add':
                     # Put in a check to reset uncovered pixels to 0
                     if self._sentinel != 0:
-                        self._sparse_map[oldsize:][_indices[self._sparse_map[_indices] != 0]] = 0
+                        self._sparse_map[oldsize:][_indices[self._sparse_map[_indices] == self._sentinel]] = 0
                     np.add.at(self._sparse_map[oldsize:], _indices, _values[out_cov])
                 elif operation == 'or':
                     np.bitwise_or.at(self._sparse_map[oldsize:], _indices, _values[out_cov])

--- a/tests/test_update_values.py
+++ b/tests/test_update_values.py
@@ -165,6 +165,69 @@ class UpdateValuesTestCase(unittest.TestCase):
         testing.assert_array_equal(sparse_map[pixels],
                                    [0, 2**1, 2**2, 0])
 
+    def test_update_values_add(self):
+        """
+        Test doing update_values with the add operation.
+        """
+        nside_coverage = 32
+        nside_map = 64
+        dtype = np.float64
+
+        for sentinel in [hpg.UNSEEN, 0.0]:
+            for update_type in ['single', 'array']:
+                sparse_map = healsparse.HealSparseMap.make_empty(
+                    nside_coverage,
+                    nside_map,
+                    dtype,
+                    sentinel=sentinel,
+                )
+
+                # Add a constant value
+                test_pix = np.array([0, 0, 10, 10, 1000, 1000, 1000, 10000])
+                if update_type == 'single':
+                    sparse_map.update_values_pix(test_pix, 1.0, operation='add')
+                else:
+                    sparse_map.update_values_pix(test_pix, np.ones(test_pix.size), operation='add')
+
+                testing.assert_array_equal(sparse_map.valid_pixels, np.unique(test_pix))
+                testing.assert_array_equal(sparse_map[sparse_map.valid_pixels], [2.0, 2.0, 3.0, 1.0])
+
+                # Try again with a constant value, with a few new pixels
+                test_pix2 = np.array([1, 1, 1])
+                if update_type == 'single':
+                    sparse_map.update_values_pix(test_pix2, 2.0, operation='add')
+                else:
+                    sparse_map.update_values_pix(test_pix2, np.full(test_pix2.size, 2.0), operation='add')
+
+                testing.assert_array_equal(
+                    sparse_map.valid_pixels,
+                    np.unique(np.concatenate((test_pix, test_pix2))),
+                )
+                testing.assert_array_equal(sparse_map[sparse_map.valid_pixels], [2.0, 6.0, 2.0, 3.0, 1.0])
+
+                # And add some more with positions
+                ra = np.array([10.0, 10.0])
+                dec = np.array([70.0, 70.0])
+                test_pix3 = hpg.angle_to_pixel(sparse_map.nside_sparse, ra, dec)
+
+                sparse_map.update_values_pos(ra, dec, 3.0, operation='add')
+
+                testing.assert_array_equal(
+                    np.sort(sparse_map.valid_pixels),
+                    np.unique(np.concatenate((test_pix, test_pix2, test_pix3))),
+                )
+                testing.assert_array_equal(
+                    sparse_map[sparse_map.valid_pixels],
+                    [2.0, 6.0, 2.0, 3.0, 1.0, 6.0],
+                )
+
+        # Test recarray raise
+        dtype = [('col1', 'f8'), ('col2', 'f8')]
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, dtype, primary='col1')
+
+        with self.assertRaises(ValueError):
+            sparse_map.update_values_pix(0, 1.0, operation='add')
+
     def test_update_values_pos(self):
         """
         Test doing update_values with positions (unique and non-unique).
@@ -176,6 +239,7 @@ class UpdateValuesTestCase(unittest.TestCase):
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, dtype)
 
         pixels = np.array([0, 1, 5, 10, 20])
+        sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, dtype)
         ra, dec = hpg.pixel_to_angle(nside_map, pixels)
 
         sparse_map.update_values_pos(ra, dec, 0.0)

--- a/tests/test_update_values.py
+++ b/tests/test_update_values.py
@@ -192,8 +192,8 @@ class UpdateValuesTestCase(unittest.TestCase):
                 testing.assert_array_equal(sparse_map.valid_pixels, np.unique(test_pix))
                 testing.assert_array_equal(sparse_map[sparse_map.valid_pixels], [2.0, 2.0, 3.0, 1.0])
 
-                # Try again with a constant value, with a few new pixels
-                test_pix2 = np.array([1, 1, 1])
+                # Try again with a constant value, with a few old and a few new pixels
+                test_pix2 = np.array([0, 0, 1, 1, 1])
                 if update_type == 'single':
                     sparse_map.update_values_pix(test_pix2, 2.0, operation='add')
                 else:
@@ -203,7 +203,7 @@ class UpdateValuesTestCase(unittest.TestCase):
                     sparse_map.valid_pixels,
                     np.unique(np.concatenate((test_pix, test_pix2))),
                 )
-                testing.assert_array_equal(sparse_map[sparse_map.valid_pixels], [2.0, 6.0, 2.0, 3.0, 1.0])
+                testing.assert_array_equal(sparse_map[sparse_map.valid_pixels], [6.0, 6.0, 2.0, 3.0, 1.0])
 
                 # And add some more with positions
                 ra = np.array([10.0, 10.0])
@@ -218,7 +218,7 @@ class UpdateValuesTestCase(unittest.TestCase):
                 )
                 testing.assert_array_equal(
                     sparse_map[sparse_map.valid_pixels],
-                    [2.0, 6.0, 2.0, 3.0, 1.0, 6.0],
+                    [6.0, 6.0, 2.0, 3.0, 1.0, 6.0],
                 )
 
         # Test recarray raise


### PR DESCRIPTION
These routines should make it easy to use healsparse to (e.g.) compute the pixelized mean of a scalar field.