### PR TITLE
Fix deprecation for astropy tile_size

### DIFF
--- a/.github/workflows/python-package-pr.yml
+++ b/.github/workflows/python-package-pr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/healsparse/fits_shim.py
+++ b/healsparse/fits_shim.py
@@ -233,10 +233,18 @@ def _write_filename(filename, c_hdr, s_hdr, cov_index_map, sparse_map,
     hdu_list.append(hdu)
 
     if compress:
-        hdu = fits.CompImageHDU(data=sparse_map, header=fits.Header(),
-                                compression_type='GZIP_2',
-                                tile_size=(compress_tilesize, ),
-                                quantize_level=0.0)
+        try:
+            # Try new tile_shape API (astropy>=5.3).
+            hdu = fits.CompImageHDU(data=sparse_map, header=fits.Header(),
+                                    compression_type='GZIP_2',
+                                    tile_shape=(compress_tilesize, ),
+                                    quantize_level=0.0)
+        except TypeError:
+            # Fall back to old tile_size API.
+            hdu = fits.CompImageHDU(data=sparse_map, header=fits.Header(),
+                                    compression_type='GZIP_2',
+                                    tile_size=(compress_tilesize, ),
+                                    quantize_level=0.0)
     else:
         if sparse_map.dtype.fields is not None:
             hdu = fits.BinTableHDU(data=sparse_map, header=fits.Header())

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -58,7 +58,6 @@ class HealSparseMap(object):
         if cov_index_map is not None and cov_map is not None:
             raise RuntimeError('Cannot specify both cov_index_map and cov_map')
         if cov_index_map is not None:
-            import warnings
             warnings.warn("cov_index_map deprecated", DeprecationWarning)
             cov_map = HealSparseCoverage(cov_index_map, nside_sparse)
 
@@ -1723,11 +1722,12 @@ class HealSparseMap(object):
         elif self._is_wide_mask:
             raise RuntimeError("Cannot convert datatype of a wide mask.")
 
-        new_sparse_map = self._sparse_map.astype(dtype)
-        _sentinel = check_sentinel(new_sparse_map.dtype.type, sentinel)
+        new_sparse_map = np.zeros(self._sparse_map.shape, dtype=dtype)
+        valid_pix = (self._sparse_map != self._sentinel)
+        new_sparse_map[valid_pix] = self._sparse_map[valid_pix].astype(dtype)
 
-        invalid_pix = (self._sparse_map == self._sentinel)
-        new_sparse_map[invalid_pix] = _sentinel
+        _sentinel = check_sentinel(new_sparse_map.dtype.type, sentinel)
+        new_sparse_map[~valid_pix] = _sentinel
 
         return HealSparseMap(cov_map=self._cov_map, sparse_map=new_sparse_map,
                              nside_sparse=self.nside_sparse, sentinel=_sentinel)


### PR DESCRIPTION
This also fixes a warning about datatype conversions and adds python=3.11 to the build matrix.