### PR TITLE
Add check for interpolating boolean maps.

### DIFF
--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -58,7 +58,7 @@ class HealSparseMap(object):
         if cov_index_map is not None and cov_map is not None:
             raise RuntimeError('Cannot specify both cov_index_map and cov_map')
         if cov_index_map is not None:
-            warnings.warn("cov_index_map deprecated", DeprecationWarning)
+            warnings.warn("cov_index_map deprecated", DeprecationWarning, stacklevel=2)
             cov_map = HealSparseCoverage(cov_index_map, nside_sparse)
 
         if cov_map is not None and sparse_map is not None and nside_sparse is not None:

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -1563,12 +1563,14 @@ class HealSparseMap(object):
         Notes
         -----
         The interpolation routing works only on numeric data, and not on wide
-        mask maps or recarray maps.
+        mask maps, recarray maps, or boolean maps.
         """
         if self._is_wide_mask:
             raise NotImplementedError("Interpolation does not run on a wide mask map.")
         elif self._is_rec_array:
             raise NotImplementedError("Interpolation does not run on a recarray map.")
+        elif isinstance(self._sentinel, bool):
+            raise NotImplementedError("Interpolation does not run on a boolean map.")
 
         interp_pix, interp_wgt = hpg.get_interpolation_weights(
             self.nside_sparse,

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -156,8 +156,10 @@ class InterpolateMapTestCase(unittest.TestCase):
         """
         Test interpolate_pos functionality with bool quantities.
         """
-        # This is a placeholder for when we add boolean map functionality.
-        pass
+        sparse_map = healsparse.HealSparseMap.make_empty(32, 64, bool, primary=False)
+
+        with self.assertRaises(NotImplementedError):
+            sparse_map.interpolate_pos(0.0, 0.0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
On the last PR I somehow got confused about whether we supported boolean maps because of an unmerged PR.  Turns out that was put on a different PR, and we do support boolean maps and need to check for them when doing interpolation.