### PR TITLE
Fix writing/reading partial parquet files

### DIFF
--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -533,7 +533,7 @@ class HealSparseMap(object):
             raise ValueError("Values are not a numpy ndarray")
 
         if hasattr(pixels, "__len__") and len(pixels) == 0:
-            if len(_values) != 0:
+            if len(_values) > 1:
                 warnings.warn("Shape mismatch: using a non-zero-length array of values "
                               "to set a zero-length list of pixels.",
                               UserWarning)

--- a/healsparse/io_map_fits.py
+++ b/healsparse/io_map_fits.py
@@ -177,7 +177,7 @@ def _read_moc_fits(healsparse_class, filename, nside_coverage):
     with HealSparseFits(filename) as fits:
         data = fits.read_ext_data(1)
 
-    order = np.round(np.log2(data['UNIQ']//4)).astype(np.int32)//2
+    order = np.floor(np.log2(data['UNIQ']//4)).astype(np.int32)//2
     index = data['UNIQ'] - 4*(4**order)
 
     max_order = np.max(order)

--- a/tests/test_emptypixels.py
+++ b/tests/test_emptypixels.py
@@ -79,9 +79,9 @@ class EmptyPixelsTestCase(unittest.TestCase):
         self.assertEqual(len(m.valid_pixels), 1)
 
         m.update_values_pix([], np.array([], dtype=np.int64))
+        m.update_values_pix([], 5)
 
         self.assertWarns(UserWarning, m.update_values_pix, [], np.zeros(5, dtype=m.dtype))
-        self.assertWarns(UserWarning, m.update_values_pix, [], 5)
 
         m.update_values_pos(
             np.array([], dtype=np.float64),
@@ -105,9 +105,9 @@ class EmptyPixelsTestCase(unittest.TestCase):
         self.assertEqual(len(m.valid_pixels), 1)
 
         m[[]] = np.array([], dtype=np.int32)
+        m[[]] = 0
 
         self.assertWarns(UserWarning, m.__setitem__, [], np.zeros(5, dtype=np.int32))
-        self.assertWarns(UserWarning, m.__setitem__, [], 100)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes row group sizing with parquet writing and therefore fixes reading of partial parquet maps.

It also removes a spurious warning when an empty pixel list is set.