### PR TITLE
Add boolean map operations and other optimizations.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,12 @@
+Version 1.8.1
+-------------
+- Add CHANGES.md
+- Add boolean mask operations (and, or, xor, invert).
+- When setting pixels with None, do not expand the coverage mask.
+
+Version 1.8.0
+-------------
+- Add bit-packed masks for efficient representation of boolean maps in memory.
+- Change to RICE compression for integer maps in FITS.
+- Use section API in astropy for faster tile reading.
+- Add support for reshaping very large compressed images persisted in FITS.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Version 1.8.1
 - Add CHANGES.md
 - Add boolean mask operations (and, or, xor, invert).
 - When setting pixels with None, do not expand the coverage mask.
+- Add get_valid_pixels_per_covpix() and valid_pixels_single_covpix() to save memory when computing valid_pixels in chunks.
 
 Version 1.8.0
 -------------

--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -77,3 +77,52 @@ For example,
     print(sum_intersection.valid_pixels.min(), sum_intersection.valid_pixels.max())
     >>> 5000 9999
 
+
+Boolean Mask Operations
+-----------------------
+
+When using boolean masks (either regular :code:`numpy.bool_` maps or :code:`bit_packed` maps), additional bitwise operations are available.
+These include ``and`` (:code:`&` and :code:`&=`); ``or`` (:code:`|` and :code:`|=`); ``xor`` (:code:`^` and :code:`^=`); and ``invert`` (:code:`~`).
+
+When a constant value is used as the right high side (RHS) of an operation, these operations are only applied over the coverage mask of the map.
+Thus, when inverting a high resolution map that only covers 3.36 deg2 (one :code:`nside=32` coverage pixel), only these pixels will be inverted and not the full 40000 deg2.
+
+When another boolean map is used as the RHS of an operation, these operations are only applied over the coverage mask of the RHS map.
+Thus, when using something like :code:`map3 = map1 | map2`, if :code:`map1` is a large map and :code:`map2` covers only a subregion, then only the subregion will be used.
+Note that the coverage of the combined map will be expanded to encompass the coverage of each of the maps to be combined.
+This makes it straightforward to build up a large mask out of many sub-maps.
+For example,
+
+.. code-block :: python
+
+    import numpy as np
+    import healsparse
+    import hpgeom as hpg
+
+    nside = 2**15
+
+    # Create a "footprint" map with some pixels.
+    footprint = healsparse.HealSparseMap.make_empty(32, nside, np.bool_, bit_packed=True)
+    footprint[hpg.query_circle(nside, 10.0, 10.0, 1.0)] = True
+
+    # Create a "bad region" map that is True for bad pixels.
+    bad_region = healsparse.HealSparseMap.make_empty(32, nside, np.bool_, bit_packed=True)
+    bad_region[hpg.query_circle(nside, 10.0, 10.5, 0.2)] = True
+
+    # Create a "good region" map that is True over a large region
+    # and false in some spots that are holes, etc.
+    good_region = healsparse.HealSparseMap.make_empty(32, nside, np.bool_, bit_packed=True)
+    good_region[hpg.query_box(nside, 9.0, 11.0, 9.0, 11.0)] = True
+    good_region[hpg.query_circle(nside, 9.5, 9.5, 0.1)] = False
+
+    # Now create a combined map.
+    combined_map = healsparse.HealSparseMap.make_empty(32, nside, np.bool_, bit_packed=True)
+
+    # The combined map should start with the footprint.
+    combined_map |= footprint
+
+    # The bad regions should be masked out.
+    combined_map &= ~bad_region
+
+    # Then apply the good region mask.
+    combined_map &= good_region

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -1313,7 +1313,7 @@ class HealSparseMap(object):
         self._n_valid = n_valid
         return n_valid
 
-    def get_valid_pixels_per_covpix(self):
+    def iter_valid_pixels_by_covpix(self):
         """
         Generator to get valid_pixels associated with each coverage pixel,
         yielded one coverage pixel at a time.
@@ -1324,7 +1324,7 @@ class HealSparseMap(object):
 
         Examples
         --------
-        >>> for valid_pixels in m.get_valid_pixels_per_covpix():
+        >>> for valid_pixels in m.iter_valid_pixels_by_covpix():
         ...     print(valid_pixels)
         """
         cov_pixels, = np.where(self._cov_map.coverage_mask)

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -2069,6 +2069,33 @@ class HealSparseMap(object):
         else:
             return self._apply_operation(other, np.bitwise_or, int_only=True, in_place=True)
 
+    def invert(self):
+        """Perform a bitwise inversion, over the coverage pixels, in place.
+        """
+        if self.dtype != np.bool_:
+            raise NotImplementedError("Can only use invert(~) on boolean maps.")
+
+        self._sparse_map[self._cov_map.nfine_per_cov:] = ~self._sparse_map[self._cov_map.nfine_per_cov:]
+        return self
+
+    def __invert__(self):
+        """
+        Perform a bit inversion, over the coverage pixels.
+
+        Only available on boolean maps.
+        """
+        if self.dtype != np.bool_:
+            raise NotImplementedError("Can only use invert(~) on boolean maps.")
+
+        sparse_map_temp = self._sparse_map.copy()
+        sparse_map_temp[self._cov_map.nfine_per_cov:] = ~sparse_map_temp[self._cov_map.nfine_per_cov:]
+        return HealSparseMap(
+            cov_map=self._cov_map.copy(),
+            sparse_map=sparse_map_temp,
+            nside_sparse=self._nside_sparse,
+            sentinel=self._sentinel,
+        )
+
     def _apply_operation(self, other, func, int_only=False, in_place=False):
         """
         Apply a generic arithmetic function.

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -443,6 +443,8 @@ class HealSparseMap(object):
         values : `np.ndarray` or `None`
             Value or Array of values.  Must be same type as sparse_map.
             If None, then the pixels will be set to the sentinel map value.
+            If None is selected then no additional coverage pixels will be
+            added as a result of the operation.
         lonlat : `bool`, optional
             If True, input angles are longitude and latitude in degrees.
             Otherwise, they are co-latitude and longitude in radians.
@@ -480,6 +482,8 @@ class HealSparseMap(object):
         values : `np.ndarray` or `None`
             Value or Array of values.  Must be same type as sparse_map.
             If None, then the pixels will be set to the sentinel map value.
+            If None is selected then no additional coverage pixels will be
+            added as a result of the operation.
         operation : `str`, optional
             Operation to use to update values.  May be 'replace' (default);
             'add'; 'or', or 'and' (for bit masks).
@@ -500,6 +504,7 @@ class HealSparseMap(object):
         self._n_valid = None
 
         # When None is specified, we use the sentinel value.
+        no_append = False
         if values is None:
             if operation != 'replace':
                 raise ValueError("Can only use 'None' with 'replace' operation.")
@@ -511,6 +516,7 @@ class HealSparseMap(object):
                 values[self._primary] = self._sentinel
             else:
                 values = self._sentinel
+            no_append = True
 
         if operation != 'replace':
             if self._is_bit_packed:
@@ -631,7 +637,7 @@ class HealSparseMap(object):
                 np.bitwise_and.at(self._sparse_map, _indices, _values[in_cov])
 
         # Update the coverage map for the rest of the pixels (if necessary)
-        if out_cov.sum() > 0:
+        if out_cov.sum() > 0 and not no_append:
             # New version to minimize data copying
 
             # Faster trick for getting unique values

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -1315,11 +1315,17 @@ class HealSparseMap(object):
 
     def get_valid_pixels_per_covpix(self):
         """
-        Get all single covpixel valid_pixels, one at a time.
+        Generator to get valid_pixels associated with each coverage pixel,
+        yielded one coverage pixel at a time.
 
         Yields
         ------
         single_pixel_valid_pixels : `np.ndarray`
+
+        Examples
+        --------
+        >>> for valid_pixels in m.get_valid_pixels_per_covpix():
+        ...     print(valid_pixels)
         """
         cov_pixels, = np.where(self._cov_map.coverage_mask)
 
@@ -1878,11 +1884,20 @@ class HealSparseMap(object):
 
     def get_covpix_maps(self):
         """
-        Get all single covpixel maps, one at a time.
+        Generator to get individual maps associated with each coverage pixel,
+        yielded one coverage pixel at a time.
+
+        This routine makes a copy of the data for each individual coverage
+        pixel map.
 
         Yields
         ------
         single_pixel_map : `HealSparseMap`
+
+        Examples
+        --------
+        >>> for covpix_map in m.get_covpix_maps():
+        ...     print(covpix_map.valid_pixels)
         """
         cov_pixels, = np.where(self._cov_map.coverage_mask)
 

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -2081,6 +2081,9 @@ class HealSparseMap(object):
         if self.dtype != np.bool_:
             raise NotImplementedError("Can only use invert(~) on boolean maps.")
 
+        # We invalidate the n_valid cache here.
+        self._n_valid = None
+
         self._sparse_map[self._cov_map.nfine_per_cov:] = ~self._sparse_map[self._cov_map.nfine_per_cov:]
         return self
 
@@ -2137,6 +2140,10 @@ class HealSparseMap(object):
             # If not int_only then it can't be used with a wide mask.
             if self._is_wide_mask:
                 raise NotImplementedError("Cannot use %s with wide mask maps" % (name))
+
+        if in_place:
+            # We invalidate the n_valid cache here.
+            self._n_valid = None
 
         other_int = False
         other_float = False
@@ -2216,6 +2223,10 @@ class HealSparseMap(object):
         """
         if name not in ("and", "or", "xor"):
             raise NotImplementedError("_apply_boolean_map_operation does not support %s" % (name))
+
+        if in_place:
+            # We invalidate the n_valid cache here.
+            self._n_valid = None
 
         start = self._cov_map.nfine_per_cov
         if in_place:

--- a/healsparse/packedBoolArray.py
+++ b/healsparse/packedBoolArray.py
@@ -49,6 +49,28 @@ class _PackedBoolArray:
             False: np.uint8(0),
         }
 
+    @classmethod
+    def from_boolean_array(cls, arr):
+        """Create a _PackedBoolArray from a numpy boolean array.
+
+        Note that the array must have a length a multiple of 8.
+
+        Parameters
+        ----------
+        arr : `np.ndarray`
+            Numpy array; must be of np.bool_ dtype.
+
+        Returns
+        -------
+        _PackedBoolArray
+        """
+        if arr.dtype != np.bool_:
+            raise NotImplementedError("Can only use from_boolean_array with a boolean array.")
+        if (arr.size % 8) != 0:
+            raise ValueError("_PackedBoolArray must have a size that is a multiple of 8.")
+
+        return cls(data_buffer=np.packbits(arr, bitorder="little"))
+
     @property
     def dtype(self):
         return self._dtype
@@ -196,6 +218,10 @@ class _PackedBoolArray:
                     if len(range(*s8.indices(len(self._data)))) != value.size // 8:
                         raise ValueError("Length of values does not match slice.")
                     self._data[s8] = np.packbits(value, bitorder="little")
+                elif isinstance(value, _PackedBoolArray):
+                    self._data[s8] = value._data
+                else:
+                    raise ValueError("Can only set to bool or array of bools or _PackedBoolArray")
             else:
                 # Unoptimized operations
                 start = key.start if key.start is not None else 0

--- a/healsparse/packedBoolArray.py
+++ b/healsparse/packedBoolArray.py
@@ -254,7 +254,7 @@ class _PackedBoolArray:
                 if value:
                     return self._set_bits_at_locs(key)
                 else:
-                    return self._clear_bits(self._data, key)
+                    return self._clear_bits_at_locs(key)
             elif isinstance(value, np.ndarray):
                 if value.dtype != self._dtype:
                     raise ValueError("Can only set to bool or array of bools")

--- a/tests/test_boolean_operations.py
+++ b/tests/test_boolean_operations.py
@@ -316,7 +316,7 @@ class BooleanOperationsTestCase(unittest.TestCase):
 
         m_temp = HealSparseMap.make_empty(32, 256, np.int32)
         with self.assertRaises(NotImplementedError):
-            m_temp2 = ~m_temp
+            _ = ~m_temp
 
         m_temp = HealSparseMap.make_empty(32, 256, np.int32)
         with self.assertRaises(NotImplementedError):

--- a/tests/test_boolean_operations.py
+++ b/tests/test_boolean_operations.py
@@ -31,16 +31,23 @@ class BooleanOperationsTestCase(unittest.TestCase):
         coverage_mask = map1.coverage_mask | map2.coverage_mask
         testing.assert_array_equal(map_new.coverage_mask, coverage_mask)
 
+        cov_pixels2, = map2.coverage_mask.nonzero()
+
         # Over these coverage pixels, we should match.
         for cov_pixel in coverage_mask.nonzero()[0]:
             pixels = np.arange(map_new._cov_map.nfine_per_cov) + cov_pixel*map_new._cov_map.nfine_per_cov
+            if cov_pixel in cov_pixels2:
+                # These should be altered.
+                if operation == "and":
+                    compare = map1[pixels] & map2[pixels]
+                elif operation == "or":
+                    compare = map1[pixels] | map2[pixels]
+                elif operation == "xor":
+                    compare = map1[pixels] ^ map2[pixels]
+            else:
+                # These should be untouched.
+                compare = map1[pixels]
 
-            if operation == "and":
-                compare = map1[pixels] & map2[pixels]
-            elif operation == "or":
-                compare = map1[pixels] | map2[pixels]
-            elif operation == "xor":
-                compare = map1[pixels] ^ map2[pixels]
             testing.assert_array_equal(
                 map_new[pixels],
                 compare,

--- a/tests/test_boolean_operations.py
+++ b/tests/test_boolean_operations.py
@@ -1,0 +1,282 @@
+import unittest
+import numpy.testing as testing
+import numpy as np
+
+from healsparse import HealSparseMap
+
+
+class BooleanOperationsTestCase(unittest.TestCase):
+    def _check_operated_maps_value(self, map_new, map_old, operation, value):
+        nfine_per_cov = map_old._cov_map.nfine_per_cov
+
+        testing.assert_array_equal(
+            map_new._sparse_map[: nfine_per_cov],
+            map_old._sparse_map[: nfine_per_cov],
+        )
+        # And the other region is as expected.
+        if operation == "and":
+            compare = map_old._sparse_map[nfine_per_cov:] & value
+        elif operation == "or":
+            compare = map_old._sparse_map[nfine_per_cov:] | value
+        elif operation == "xor":
+            compare = map_old._sparse_map[nfine_per_cov:] ^ value
+
+        testing.assert_array_equal(
+            map_new._sparse_map[nfine_per_cov:],
+            compare
+        )
+
+    def _check_operated_maps_map(self, map_new, map1, operation, map2):
+        # Check combined coverage mask.
+        coverage_mask = map1.coverage_mask | map2.coverage_mask
+        testing.assert_array_equal(map_new.coverage_mask, coverage_mask)
+
+        # Over these coverage pixels, we should match.
+        for cov_pixel in coverage_mask.nonzero()[0]:
+            pixels = np.arange(map_new._cov_map.nfine_per_cov) + cov_pixel*map_new._cov_map.nfine_per_cov
+
+            if operation == "and":
+                compare = map1[pixels] & map2[pixels]
+            elif operation == "or":
+                compare = map1[pixels] | map2[pixels]
+            elif operation == "xor":
+                compare = map1[pixels] ^ map2[pixels]
+            testing.assert_array_equal(
+                map_new[pixels],
+                compare,
+            )
+
+    def test_and_const(self):
+        m_bool = HealSparseMap.make_empty(32, 256, np.bool_)
+        m_bool[0: 1000] = True
+        m_bool[500_000: 600_000] = True
+
+        m_bool2 = m_bool & True
+        self._check_operated_maps_value(m_bool2, m_bool, "and", True)
+        m_bool2 = m_bool & False
+        self._check_operated_maps_value(m_bool2, m_bool, "and", False)
+
+        m_bool2 = m_bool.copy()
+        m_bool2 &= True
+        self._check_operated_maps_value(m_bool2, m_bool, "and", True)
+        m_bool2 = m_bool.copy()
+        m_bool2 &= False
+        self._check_operated_maps_value(m_bool2, m_bool, "and", False)
+
+        m_packed = m_bool.as_bit_packed_map()
+        m_packed2 = m_packed & True
+        self._check_operated_maps_value(m_packed2, m_packed, "and", True)
+        m_packed2 = m_packed & False
+        self._check_operated_maps_value(m_packed2, m_packed, "and", False)
+
+        m_packed2 = m_packed.copy()
+        m_packed2 &= True
+        self._check_operated_maps_value(m_packed2, m_packed, "and", True)
+        m_packed2 = m_packed.copy()
+        m_packed2 &= False
+        self._check_operated_maps_value(m_packed2, m_packed, "and", False)
+
+    def test_or_const(self):
+        m_bool = HealSparseMap.make_empty(32, 256, np.bool_)
+        m_bool[0: 1000] = True
+        m_bool[500_000: 600_000] = True
+
+        m_bool2 = m_bool | True
+        self._check_operated_maps_value(m_bool2, m_bool, "or", True)
+        m_bool2 = m_bool | False
+        self._check_operated_maps_value(m_bool2, m_bool, "or", False)
+
+        m_bool2 = m_bool.copy()
+        m_bool2 |= True
+        self._check_operated_maps_value(m_bool2, m_bool, "or", True)
+        m_bool2 = m_bool.copy()
+        m_bool2 |= False
+        self._check_operated_maps_value(m_bool2, m_bool, "or", False)
+
+        m_packed = m_bool.as_bit_packed_map()
+        m_packed2 = m_packed | True
+        self._check_operated_maps_value(m_packed2, m_packed, "or", True)
+        m_packed2 = m_packed | False
+        self._check_operated_maps_value(m_packed2, m_packed, "or", False)
+
+        m_packed2 = m_packed.copy()
+        m_packed2 |= True
+        self._check_operated_maps_value(m_packed2, m_packed, "or", True)
+        m_packed2 = m_packed.copy()
+        m_packed2 |= False
+        self._check_operated_maps_value(m_packed2, m_packed, "or", False)
+
+    def test_xor_const(self):
+        m_bool = HealSparseMap.make_empty(32, 256, np.bool_)
+        m_bool[0: 1000] = True
+        m_bool[500_000: 600_000] = True
+
+        m_bool2 = m_bool ^ True
+        self._check_operated_maps_value(m_bool2, m_bool, "xor", True)
+        m_bool2 = m_bool ^ False
+        self._check_operated_maps_value(m_bool2, m_bool, "xor", False)
+
+        m_bool2 = m_bool.copy()
+        m_bool2 ^= True
+        self._check_operated_maps_value(m_bool2, m_bool, "xor", True)
+        m_bool2 = m_bool.copy()
+        m_bool2 ^= False
+        self._check_operated_maps_value(m_bool2, m_bool, "xor", False)
+
+        m_packed = m_bool.as_bit_packed_map()
+        m_packed2 = m_packed ^ True
+        self._check_operated_maps_value(m_packed2, m_packed, "xor", True)
+        m_packed2 = m_packed ^ False
+        self._check_operated_maps_value(m_packed2, m_packed, "xor", False)
+
+        m_packed2 = m_packed.copy()
+        m_packed2 ^= True
+        self._check_operated_maps_value(m_packed2, m_packed, "xor", True)
+        m_packed2 = m_packed.copy()
+        m_packed2 ^= False
+        self._check_operated_maps_value(m_packed2, m_packed, "xor", False)
+
+    def test_and_map(self):
+        # We need to test several combinations.
+        #  bool/bool, bool/packed, packed/bool, packed/packed
+        #  Same coverage, first with more, second with more
+
+        for cov_type in ["same", "first", "second"]:
+            m_bool = HealSparseMap.make_empty(32, 256, np.bool_)
+            m2_bool = HealSparseMap.make_empty(32, 256, np.bool_)
+
+            if cov_type == "same":
+                m_bool[10_000: 50_000] = True
+                m2_bool[10_000: 50_000] = True
+                m2_bool[15_000: 16_000] = False
+            elif cov_type == "first":
+                m_bool[10_000: 50_000] = True
+                m2_bool[10_000: 20_000] = True
+                m2_bool[15_000: 16_000] = False
+            elif cov_type == "second":
+                m_bool[10_000: 20_000] = True
+                m2_bool[10_000: 50_000] = True
+                m2_bool[15_000: 16_000] = False
+
+            for combo in range(4):
+                if combo == 0:
+                    # Bool/Bool
+                    map1 = m_bool
+                    map2 = m2_bool
+                elif combo == 1:
+                    # Bool/Packed
+                    map1 = m_bool
+                    map2 = m2_bool.as_bit_packed_map()
+                elif combo == 2:
+                    # Packed/Bool
+                    map1 = m_bool.as_bit_packed_map()
+                    map2 = m2_bool
+                else:
+                    # Packed/Packed
+                    map1 = m_bool.as_bit_packed_map()
+                    map2 = m2_bool.as_bit_packed_map()
+
+                map3 = map1 & map2
+                self._check_operated_maps_map(map3, map1, "and", map2)
+
+                map3 = map1.copy()
+                map3 &= map2
+                self._check_operated_maps_map(map3, map1, "and", map2)
+
+    def test_or_map(self):
+        # We need to test several combinations.
+        #  bool/bool, bool/packed, packed/bool, packed/packed
+        #  Same coverage, first with more, second with more
+
+        for cov_type in ["same", "first", "second"]:
+            m_bool = HealSparseMap.make_empty(32, 256, np.bool_)
+            m2_bool = HealSparseMap.make_empty(32, 256, np.bool_)
+
+            if cov_type == "same":
+                m_bool[10_000: 50_000] = True
+                m2_bool[10_000: 50_000] = True
+                m2_bool[15_000: 16_000] = False
+            elif cov_type == "first":
+                m_bool[10_000: 50_000] = True
+                m2_bool[10_000: 20_000] = True
+                m2_bool[15_000: 16_000] = False
+            elif cov_type == "second":
+                m_bool[10_000: 20_000] = True
+                m2_bool[10_000: 50_000] = True
+                m2_bool[15_000: 16_000] = False
+
+            for combo in range(4):
+                if combo == 0:
+                    # Bool/Bool
+                    map1 = m_bool
+                    map2 = m2_bool
+                elif combo == 1:
+                    # Bool/Packed
+                    map1 = m_bool
+                    map2 = m2_bool.as_bit_packed_map()
+                elif combo == 2:
+                    # Packed/Bool
+                    map1 = m_bool.as_bit_packed_map()
+                    map2 = m2_bool
+                else:
+                    # Packed/Packed
+                    map1 = m_bool.as_bit_packed_map()
+                    map2 = m2_bool.as_bit_packed_map()
+
+                map3 = map1 | map2
+                self._check_operated_maps_map(map3, map1, "or", map2)
+
+                map3 = map1.copy()
+                map3 |= map2
+                self._check_operated_maps_map(map3, map1, "or", map2)
+
+    def test_xor_map(self):
+        # We need to test several combinations.
+        #  bool/bool, bool/packed, packed/bool, packed/packed
+        #  Same coverage, first with more, second with more
+
+        for cov_type in ["same", "first", "second"]:
+            m_bool = HealSparseMap.make_empty(32, 256, np.bool_)
+            m2_bool = HealSparseMap.make_empty(32, 256, np.bool_)
+
+            if cov_type == "same":
+                m_bool[10_000: 50_000] = True
+                m2_bool[10_000: 50_000] = True
+                m2_bool[15_000: 16_000] = False
+            elif cov_type == "first":
+                m_bool[10_000: 50_000] = True
+                m2_bool[10_000: 20_000] = True
+                m2_bool[15_000: 16_000] = False
+            elif cov_type == "second":
+                m_bool[10_000: 20_000] = True
+                m2_bool[10_000: 50_000] = True
+                m2_bool[15_000: 16_000] = False
+
+            for combo in range(4):
+                if combo == 0:
+                    # Bool/Bool
+                    map1 = m_bool
+                    map2 = m2_bool
+                elif combo == 1:
+                    # Bool/Packed
+                    map1 = m_bool
+                    map2 = m2_bool.as_bit_packed_map()
+                elif combo == 2:
+                    # Packed/Bool
+                    map1 = m_bool.as_bit_packed_map()
+                    map2 = m2_bool
+                else:
+                    # Packed/Packed
+                    map1 = m_bool.as_bit_packed_map()
+                    map2 = m2_bool.as_bit_packed_map()
+
+                map3 = map1 ^ map2
+                self._check_operated_maps_map(map3, map1, "xor", map2)
+
+                map3 = map1.copy()
+                map3 ^= map2
+                self._check_operated_maps_map(map3, map1, "xor", map2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_boolean_operations.py
+++ b/tests/test_boolean_operations.py
@@ -314,6 +314,14 @@ class BooleanOperationsTestCase(unittest.TestCase):
             ~m_packed._sparse_map[m_packed2._cov_map.nfine_per_cov:],
         )
 
+        m_temp = HealSparseMap.make_empty(32, 256, np.int32)
+        with self.assertRaises(NotImplementedError):
+            m_temp2 = ~m_temp
+
+        m_temp = HealSparseMap.make_empty(32, 256, np.int32)
+        with self.assertRaises(NotImplementedError):
+            m_temp.invert()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_boolean_operations.py
+++ b/tests/test_boolean_operations.py
@@ -277,6 +277,43 @@ class BooleanOperationsTestCase(unittest.TestCase):
                 map3 ^= map2
                 self._check_operated_maps_map(map3, map1, "xor", map2)
 
+    def test_invert(self):
+        m_bool = HealSparseMap.make_empty(32, 256, np.bool_)
+        m_bool[0: 1000] = True
+        m_bool[500_000: 600_000] = True
+
+        m_bool2 = ~m_bool
+
+        testing.assert_array_equal(
+            m_bool2._sparse_map[m_bool2._cov_map.nfine_per_cov:],
+            ~m_bool._sparse_map[m_bool2._cov_map.nfine_per_cov:],
+        )
+
+        m_bool2 = m_bool.copy()
+        m_bool2.invert()
+
+        testing.assert_array_equal(
+            m_bool2._sparse_map[m_bool2._cov_map.nfine_per_cov:],
+            ~m_bool._sparse_map[m_bool2._cov_map.nfine_per_cov:],
+        )
+
+        m_packed = m_bool.as_bit_packed_map()
+        m_packed2 = ~m_packed
+
+        testing.assert_array_equal(
+            m_packed2._sparse_map[m_packed2._cov_map.nfine_per_cov:],
+            ~m_packed._sparse_map[m_packed2._cov_map.nfine_per_cov:],
+        )
+
+        m_packed = m_bool.as_bit_packed_map()
+        m_packed2 = m_packed.copy()
+        m_packed2.invert()
+
+        testing.assert_array_equal(
+            m_packed2._sparse_map[m_packed2._cov_map.nfine_per_cov:],
+            ~m_packed._sparse_map[m_packed2._cov_map.nfine_per_cov:],
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_getset.py
+++ b/tests/test_getset.py
@@ -264,6 +264,20 @@ class GetSetTestCase(unittest.TestCase):
         testing.assert_array_almost_equal(sparse_map.generate_healpix_map(),
                                           full_map)
 
+        # Test None
+        sparse_map[10000] = None
+        full_map[10000] = sparse_map.sentinel
+        testing.assert_array_almost_equal(sparse_map.generate_healpix_map(),
+                                          full_map)
+
+        # Test None (no append)
+        covmask_orig = sparse_map.coverage_mask
+        sparse_map[10500: 15000] = None
+        full_map[10500: 15000] = sparse_map.sentinel
+        testing.assert_array_almost_equal(sparse_map.generate_healpix_map(),
+                                          full_map)
+        testing.assert_array_equal(sparse_map.coverage_mask, covmask_orig)
+
         # Test all
         sparse_map[:] = np.array([1.0])
         full_map[:] = np.array([1.0])

--- a/tests/test_packedboolarray.py
+++ b/tests/test_packedboolarray.py
@@ -35,6 +35,23 @@ class PackedBoolArrayTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             m = _PackedBoolArray(size=6)
 
+    def test_create_from_bool_array(self):
+        arr = np.zeros(128, dtype=np.bool_)
+        arr[100: 120] = True
+
+        m = _PackedBoolArray.from_boolean_array(arr)
+
+        self.assertEqual(m.size, arr.size)
+        testing.assert_array_equal(np.array(m), arr)
+
+        with self.assertRaises(ValueError):
+            arr = np.zeros(122, dtype=np.bool_)
+            m = _PackedBoolArray.from_boolean_array(arr)
+
+        with self.assertRaises(NotImplementedError):
+            arr = np.zeros(128, dtype=np.int32)
+            m = _PackedBoolArray.from_boolean_array(arr)
+
     def test_resize(self):
         m = _PackedBoolArray(size=0)
         m.resize(2**10)
@@ -136,6 +153,18 @@ class PackedBoolArrayTestCase(unittest.TestCase):
         m[0: 62] = values
         arr = np.array(m)
         testing.assert_array_equal(arr[0: 62], values)
+
+    def test_setitem_slice_optimized_pba(self):
+        m = _PackedBoolArray(size=2**10)
+
+        values = _PackedBoolArray(size=64)
+        values[10: 20] = True
+
+        m[0: 64] = values
+        testing.assert_array_equal(m[0: 64], values)
+
+        # Note there isn't an "unoptimized" version because you can't have
+        # non-8 slices of a _PackedBoolArray.
 
     def test_setgetitiem_indices(self):
         m = _PackedBoolArray(size=2**10)

--- a/tests/test_packedboolarray.py
+++ b/tests/test_packedboolarray.py
@@ -208,6 +208,155 @@ class PackedBoolArrayTestCase(unittest.TestCase):
         self.assertEqual(sum2[100 // 8], 1)
         self.assertEqual(sum2[1000 // 8], 1)
 
+    def test_and(self):
+        m = _PackedBoolArray(size=128)
+        m[8: 24] = True
+
+        # Test __and__ (boolean)
+        m2 = m & True
+        testing.assert_array_equal(np.array(m2), np.array(m) & True)
+        m2 = m & False
+        testing.assert_array_equal(np.array(m2), np.array(m) & False)
+
+        # Test __and__ (_PackedBoolArray)
+        m2 = _PackedBoolArray(size=128)
+        m2[8: 32] = True
+        m3 = m & m2
+        testing.assert_array_equal(np.array(m3), np.array(m) & np.array(m2))
+
+        # Illegal __and__ operations.
+        with self.assertRaises(ValueError):
+            m3 = m & _PackedBoolArray(size=64)
+
+        with self.assertRaises(NotImplementedError):
+            m3 = m & 1
+
+        # Test __iand__ (boolean)
+        m2 = m.copy()
+        m2 &= True
+        testing.assert_array_equal(np.array(m2), np.array(m) & True)
+        m2 = m.copy()
+        m2 &= False
+        testing.assert_array_equal(np.array(m2), np.array(m) & False)
+
+        # Test __iand__ (_PackedBoolArray)
+        m2 = _PackedBoolArray(size=128)
+        m2[8: 32] = True
+        m3 = m.copy()
+        m3 &= m2
+        testing.assert_array_equal(np.array(m3), np.array(m) & np.array(m2))
+
+        # Illegal __iand__ operations.
+        with self.assertRaises(ValueError):
+            m3 = m.copy()
+            m3 &= _PackedBoolArray(size=64)
+
+        with self.assertRaises(NotImplementedError):
+            m3 = m.copy()
+            m3 &= 1
+
+    def test_or(self):
+        m = _PackedBoolArray(size=128)
+        m[8: 24] = True
+
+        # Test __or__ (boolean)
+        m2 = m | True
+        testing.assert_array_equal(np.array(m2), np.array(m) | True)
+        m2 = m | False
+        testing.assert_array_equal(np.array(m2), np.array(m) | False)
+
+        # Test __or__ (_PackedBoolArray)
+        m2 = _PackedBoolArray(size=128)
+        m2[8: 32] = True
+        m3 = m | m2
+        testing.assert_array_equal(np.array(m3), np.array(m) | np.array(m2))
+
+        # Illegal __or__ operations.
+        with self.assertRaises(ValueError):
+            m3 = m | _PackedBoolArray(size=64)
+
+        with self.assertRaises(NotImplementedError):
+            m3 = m | 1
+
+        # Test __ior__ (boolean)
+        m2 = m.copy()
+        m2 |= True
+        testing.assert_array_equal(np.array(m2), np.array(m) | True)
+        m2 = m.copy()
+        m2 |= False
+        testing.assert_array_equal(np.array(m2), np.array(m) | False)
+
+        # Test __ior__ (_PackedBoolArray)
+        m2 = _PackedBoolArray(size=128)
+        m2[8: 32] = True
+        m3 = m.copy()
+        m3 |= m2
+        testing.assert_array_equal(np.array(m3), np.array(m) | np.array(m2))
+
+        # Illegal __ior__ operations.
+        with self.assertRaises(ValueError):
+            m3 = m.copy()
+            m3 |= _PackedBoolArray(size=64)
+
+        with self.assertRaises(NotImplementedError):
+            m3 = m.copy()
+            m3 |= 1
+
+    def test_xor(self):
+        m = _PackedBoolArray(size=128)
+        m[8: 24] = True
+
+        # Test __xor__ (boolean)
+        m2 = m ^ True
+        testing.assert_array_equal(np.array(m2), np.array(m) ^ True)
+        m2 = m ^ False
+        testing.assert_array_equal(np.array(m2), np.array(m) ^ False)
+
+        # Test __xor__ (_PackedBoolArray)
+        m2 = _PackedBoolArray(size=128)
+        m2[8: 32] = True
+        m3 = m ^ m2
+        testing.assert_array_equal(np.array(m3), np.array(m) ^ np.array(m2))
+
+        # Illegal __xor__ operations.
+        with self.assertRaises(ValueError):
+            m3 = m ^ _PackedBoolArray(size=64)
+
+        with self.assertRaises(NotImplementedError):
+            m3 = m ^ 1
+
+        # Test __ixor__ (boolean)
+        m2 = m.copy()
+        m2 ^= True
+        testing.assert_array_equal(np.array(m2), np.array(m) ^ True)
+        m2 = m.copy()
+        m2 ^= False
+        testing.assert_array_equal(np.array(m2), np.array(m) ^ False)
+
+        # Test __ixor__ (_PackedBoolArray)
+        m2 = _PackedBoolArray(size=128)
+        m2[8: 32] = True
+        m3 = m.copy()
+        m3 ^= m2
+        testing.assert_array_equal(np.array(m3), np.array(m) ^ np.array(m2))
+
+        # Illegal __ixor__ operations.
+        with self.assertRaises(ValueError):
+            m3 = m.copy()
+            m3 ^= _PackedBoolArray(size=64)
+
+        with self.assertRaises(NotImplementedError):
+            m3 = m.copy()
+            m3 ^= 1
+
+    def test_invert(self):
+        m = _PackedBoolArray(size=128)
+        m[8: 24] = True
+
+        # Test __invert__
+        m2 = ~m
+        testing.assert_array_equal(np.array(m2), ~np.array(m))
+
 
 class HealSparseBitPackedTestCase(unittest.TestCase):
     """Tests for HealSparseMap with bit_packed."""

--- a/tests/test_single_covpix.py
+++ b/tests/test_single_covpix.py
@@ -27,6 +27,7 @@ class SingleCovpixTestCase(unittest.TestCase):
             self.assertEqual(len(sub_cov_pixels), 1)
             self.assertEqual(sub_cov_pixels[0], cov_pixel)
             self.assertEqual(sub_map.n_valid, 1)
+            testing.assert_array_equal(sub_map.valid_pixels, pixels[i])
             testing.assert_almost_equal(sub_map[pixels[i]], 1.0)
 
     def test_get_single_pixel_in_map_recarray(self):
@@ -54,6 +55,7 @@ class SingleCovpixTestCase(unittest.TestCase):
             self.assertEqual(len(sub_cov_pixels), 1)
             self.assertEqual(sub_cov_pixels[0], cov_pixel)
             self.assertEqual(sub_map.n_valid, 1)
+            testing.assert_array_equal(sub_map.valid_pixels, pixels[i])
             testing.assert_almost_equal(sub_map[pixels[i]]['a'], 1.0)
             self.assertEqual(sub_map[pixels[i]]['b'], 1)
 
@@ -81,6 +83,7 @@ class SingleCovpixTestCase(unittest.TestCase):
             self.assertEqual(len(sub_cov_pixels), 1)
             self.assertEqual(sub_cov_pixels[0], cov_pixel)
             self.assertEqual(sub_map.n_valid, 1)
+            testing.assert_array_equal(sub_map.valid_pixels, pixels[i])
             self.assertEqual(sub_map.check_bits_pix(pixels[i], [4]), True)
             self.assertEqual(sub_map.check_bits_pix(pixels[i], [13]), True)
 
@@ -101,6 +104,7 @@ class SingleCovpixTestCase(unittest.TestCase):
         sub_cov_pixels, = np.where(sub_map.coverage_mask)
         self.assertEqual(len(sub_cov_pixels), 0)
         self.assertEqual(sub_map.n_valid, 0)
+        self.assertEqual(len(sub_map.valid_pixels), 0)
 
     def test_single_pixel_generator(self):
         """
@@ -119,9 +123,11 @@ class SingleCovpixTestCase(unittest.TestCase):
 
         for i, sub_map in enumerate(sparse_map.get_covpix_maps()):
             sub_cov_pixels, = np.where(sub_map.coverage_mask)
+
             self.assertEqual(len(sub_cov_pixels), 1)
             self.assertEqual(sub_cov_pixels[0], cov_pixels[i])
             self.assertEqual(sub_map.n_valid, 1)
+            testing.assert_array_equal(sub_map.valid_pixels, pixels[i])
             testing.assert_almost_equal(sub_map[pixels[i]], 1.0)
 
 

--- a/tests/test_single_covpix.py
+++ b/tests/test_single_covpix.py
@@ -148,7 +148,7 @@ class SingleCovpixTestCase(unittest.TestCase):
             testing.assert_array_equal(sub_map.valid_pixels, pixels[i])
             testing.assert_almost_equal(sub_map[pixels[i]], 1.0)
 
-        for i, sub_valid_pixels in enumerate(sparse_map.get_valid_pixels_per_covpix()):
+        for i, sub_valid_pixels in enumerate(sparse_map.iter_valid_pixels_by_covpix()):
             self.assertEqual(len(sub_valid_pixels), 1)
             testing.assert_array_equal(sub_valid_pixels, pixels[i])
 

--- a/tests/test_single_covpix.py
+++ b/tests/test_single_covpix.py
@@ -30,6 +30,11 @@ class SingleCovpixTestCase(unittest.TestCase):
             testing.assert_array_equal(sub_map.valid_pixels, pixels[i])
             testing.assert_almost_equal(sub_map[pixels[i]], 1.0)
 
+            # Test getting the cov_pixel valid_pixels from the full map.
+            sub_valid_pixels = sparse_map.valid_pixels_single_covpix(cov_pixel)
+            self.assertEqual(len(sub_valid_pixels), 1)
+            testing.assert_array_equal(sub_valid_pixels, pixels[i])
+
     def test_get_single_pixel_in_map_recarray(self):
         """
         Test getting a single coverage pixel in a recarray map.
@@ -59,6 +64,11 @@ class SingleCovpixTestCase(unittest.TestCase):
             testing.assert_almost_equal(sub_map[pixels[i]]['a'], 1.0)
             self.assertEqual(sub_map[pixels[i]]['b'], 1)
 
+            # Test getting the cov_pixel valid_pixels from the full map.
+            sub_valid_pixels = sparse_map.valid_pixels_single_covpix(cov_pixel)
+            self.assertEqual(len(sub_valid_pixels), 1)
+            testing.assert_array_equal(sub_valid_pixels, pixels[i])
+
     def test_get_single_pixel_in_map_wide(self):
         """
         Test getting a single coverage pixel in a wide mask map.
@@ -87,6 +97,11 @@ class SingleCovpixTestCase(unittest.TestCase):
             self.assertEqual(sub_map.check_bits_pix(pixels[i], [4]), True)
             self.assertEqual(sub_map.check_bits_pix(pixels[i], [13]), True)
 
+            # Test getting the cov_pixel valid_pixels from the full map.
+            sub_valid_pixels = sparse_map.valid_pixels_single_covpix(cov_pixel)
+            self.assertEqual(len(sub_valid_pixels), 1)
+            testing.assert_array_equal(sub_valid_pixels, pixels[i])
+
     def test_get_single_pixel_not_in_map(self):
         """
         Test getting a single coverage pixel map that is not in the map.
@@ -105,6 +120,9 @@ class SingleCovpixTestCase(unittest.TestCase):
         self.assertEqual(len(sub_cov_pixels), 0)
         self.assertEqual(sub_map.n_valid, 0)
         self.assertEqual(len(sub_map.valid_pixels), 0)
+
+        sub_valid_pixels = sparse_map.valid_pixels_single_covpix(40)
+        self.assertEqual(len(sub_valid_pixels), 0)
 
     def test_single_pixel_generator(self):
         """
@@ -129,6 +147,10 @@ class SingleCovpixTestCase(unittest.TestCase):
             self.assertEqual(sub_map.n_valid, 1)
             testing.assert_array_equal(sub_map.valid_pixels, pixels[i])
             testing.assert_almost_equal(sub_map[pixels[i]], 1.0)
+
+        for i, sub_valid_pixels in enumerate(sparse_map.get_valid_pixels_per_covpix()):
+            self.assertEqual(len(sub_valid_pixels), 1)
+            testing.assert_array_equal(sub_valid_pixels, pixels[i])
 
 
 if __name__ == '__main__':

--- a/tests/test_singlevalues.py
+++ b/tests/test_singlevalues.py
@@ -40,6 +40,11 @@ class SingleValuesTestCase(unittest.TestCase):
         m[50] = None
         self.assertEqual(m[50], m.sentinel)
 
+        # Test None (no append)
+        covmask_orig = m.coverage_mask
+        m[1000] = None
+        testing.assert_array_equal(m.coverage_mask, covmask_orig)
+
         # Test floating point
         self.assertRaises(ValueError, m.update_values_pix, np.arange(100),
                           1.0)
@@ -87,6 +92,11 @@ class SingleValuesTestCase(unittest.TestCase):
         m[50] = None
         self.assertEqual(m[50], m.sentinel)
 
+        # Test None (no append)
+        covmask_orig = m.coverage_mask
+        m[1000] = None
+        testing.assert_array_equal(m.coverage_mask, covmask_orig)
+
         # Test int
         self.assertRaises(ValueError, m.update_values_pix, np.arange(100),
                           1)
@@ -120,6 +130,11 @@ class SingleValuesTestCase(unittest.TestCase):
         m[50] = None
         self.assertEqual(m[50][m.primary], m.sentinel)
 
+        # Test None (no append)
+        covmask_orig = m.coverage_mask
+        m[1000] = None
+        testing.assert_array_equal(m.coverage_mask, covmask_orig)
+
         # Test wrong dtype recarray
         val = np.ones(1, dtype=[('a', 'f4'), ('b', 'f4')])
         self.assertRaises(ValueError, m.update_values_pix, np.arange(100), val)
@@ -149,6 +164,11 @@ class SingleValuesTestCase(unittest.TestCase):
         m[50] = None
         self.assertEqual(m[50][0], 0)
         self.assertEqual(m[50][1], 0)
+
+        # Test None (no append)
+        covmask_orig = m.coverage_mask
+        m[1000] = None
+        testing.assert_array_equal(m.coverage_mask, covmask_orig)
 
         self.assertRaises(ValueError, m.update_values_pix, np.arange(100), 1)
         self.assertRaises(ValueError, m.update_values_pix, np.arange(100),


### PR DESCRIPTION
This PR adds operations for boolean maps (both numpy array and bit packed) to make it easy to do `&`, `|`, `^`, and `~`.  This makes it straightforward to combine maps.

This also adds a convenience routine to get valid pixels per coverage pixel to save memory when using very large masks.