### PR TITLE
Quick fix for high memory usage when printing summary of a bit packed map.

### DIFF
--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -2562,6 +2562,14 @@ class HealSparseMap(object):
         else:
             descr += ', ' + self._sparse_map.dtype.name
 
-        descr += ', %d valid pixels' % (self.n_valid)
+        add_n_valid = True
+        if self._is_bit_packed and self._n_valid is None:
+            # Only plot the number of valid pixels if we have
+            # previously computed it. This is to keep the memory
+            # from blowing up until we optimize this operation.
+            add_n_valid = False
+
+        if add_n_valid:
+            descr += ', %d valid pixels' % (self.n_valid)
 
         return descr

--- a/healsparse/packedBoolArray.py
+++ b/healsparse/packedBoolArray.py
@@ -208,9 +208,9 @@ class _PackedBoolArray:
         first_unpacked, mid_data, last_unpacked = self._extract_first_middle_last(mask_extra=True)
         new_buffer = self._data.copy()
         if first_unpacked[0] is not None:
-            new_buffer[0] = np.packbits(first_unpacked[0], bitorder="little")
+            new_buffer[0] = np.packbits(first_unpacked[0], bitorder="little")[0]
         if last_unpacked[0] is not None:
-            new_buffer[-1] = np.packbits(last_unpacked[0], bitorder="little")
+            new_buffer[-1] = np.packbits(last_unpacked[0], bitorder="little")[0]
 
         return _PackedBoolArray(
             data_buffer=new_buffer,


### PR DESCRIPTION
As pointed out in #154 printing a large bit packed map can use a lot of memory.  To truly fix this requires some c code, which will be added in the near future.  In the meantime, we can fix the problem by not auto-printing the number of pixels.

This also uses a slightly more memory efficient lookup table for bit counting.