### PR TITLE
Add nside_render to geom objects to allow for rendering at a different (coarser) resolution than the corresponding map.

### DIFF
--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -4,7 +4,9 @@
 HealSparse Geometry
 ===================
 
-:code:`HealSparse` has a basic geometry library that allows you to generate maps from circles, convex polygons, and ellipses as supported by :code:`hpgeom`.  Each geometric object is associated with a single value.  On construction, geometry objects only contain information about the shape, and they are only rendered onto a `HEALPix` grid when requested.
+:code:`HealSparse` has a basic geometry library that allows you to generate maps from circles, convex polygons, ellipses, and boxes as supported by :code:`hpgeom`.
+Each geometric object is associated with a single value.
+On construction, geometry objects only contain information about the shape, and they are only rendered onto a `HEALPix` grid when requested.
 
 There are a few methods to realize geometry objects.
 The easiest is to combine a geometric object with a :code:`HealSparseMap` map, with the ``or``, ``and``, or ``add`` operation.
@@ -15,7 +17,8 @@ Finally, for integer-value objects one can use the :code:`realize_geom()` method
 HealSparse Geometry Shapes
 --------------------------
 
-The three shapes supported are :code:`Circle`, :code:`Ellipse`, and :code:`Polygon`.  They share a base class, and while the instantiation is different, the operations are the same.
+The four shapes supported are :code:`Circle`, :code:`Ellipse`, :code:`Polygon`, and :code:`Box`.
+They share a base class, and while the instantiation is different, the operations are the same.
 
 **Circle**
 
@@ -49,11 +52,23 @@ The three shapes supported are :code:`Circle`, :code:`Ellipse`, and :code:`Polyg
                               value=8)
 
 
+**Box**
+
+.. code-block :: python
+
+    # All units are decimal degrees
+    # A box differs from a polygon in that the sides will be constant ra/dec rather
+    # than great circles.
+    # See https://hpgeom.readthedocs.io/en/latest .
+    box = healsparse.Box(ra1=20.0, ra2=30.0, dec1=10.0, dec2=5.0, value=True)
+
+
 Combining Geometric Objects with Maps
 -------------------------------------
 
 Given a map, it is very simple to combine geometric objects to build up complex shapes/masks/etc.
 Behind the scenes, large geometric objects are rendered with :code:`hpgeom` pixel ranges which leads to greater memory efficiency.
+Note that these operations can be applied to integer or boolean maps.
 
 .. code-block :: python
 
@@ -89,7 +104,8 @@ To make a map from a geometry object, use the :code:`get_map()` method as such. 
 Using :code:`realize_geom()`
 ----------------------------
 
-You can only use :code:`realize_geom()` to create maps from combinations of polygons if you are using integer maps, and want to :code:`or` them together.  This method is more memory efficient than generating each individual individual map and combining them, as above.
+You can only use :code:`realize_geom()` to create maps from combinations of polygons if you are using integer maps, and want to :code:`or` them together.
+This method is more memory efficient than generating each individual individual map and combining them, as above.
 
 .. code-block :: python
 

--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -8,6 +8,11 @@ HealSparse Geometry
 Each geometric object is associated with a single value.
 On construction, geometry objects only contain information about the shape, and they are only rendered onto a `HEALPix` grid when requested.
 
+In addition to information about the shape itself, a geometric object may optionally contain a value of :code:`nside_render`.
+This indicates that the shape should always be rendered at this given resolution, no matter the resolution of the map that it is being combined with.
+(Note that you can only render at a resolution that is less than or equal to the map resolution, or else a :code:`ValueError` is raised.)
+This functionality may be useful if one is building a map that may be used with multiple resolutions, and one wants to ensure that a higher and lower resolution maps have exactly the same outline for these shapes.
+
 There are a few methods to realize geometry objects.
 The easiest is to combine a geometric object with a :code:`HealSparseMap` map, with the ``or``, ``and``, or ``add`` operation.
 One can generate a :code:`HealSparseMap` from the geometric object.

--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -12,6 +12,7 @@ In addition to information about the shape itself, a geometric object may option
 This indicates that the shape should always be rendered at this given resolution, no matter the resolution of the map that it is being combined with.
 (Note that you can only render at a resolution that is less than or equal to the map resolution, or else a :code:`ValueError` is raised.)
 This functionality may be useful if one is building a map that may be used with multiple resolutions, and one wants to ensure that a higher and lower resolution maps have exactly the same outline for these shapes.
+If no :code:`nside_render` is set with the object it will always be rendered at the same resolution as the corresponding map or via the :code:`nside` parameter of :code:`get_pixels()` and :code:`get_pixel_ranges()`.
 
 There are a few methods to realize geometry objects.
 The easiest is to combine a geometric object with a :code:`HealSparseMap` map, with the ``or``, ``and``, or ``add`` operation.

--- a/healsparse/__init__.py
+++ b/healsparse/__init__.py
@@ -21,6 +21,6 @@ from .operations import max_intersection, min_intersection, max_union, min_union
 from .operations import ufunc_union, ufunc_intersection
 from .operations import divide_intersection, floor_divide_intersection
 from . import geom
-from .geom import Circle, Ellipse, Polygon, realize_geom
+from .geom import Box, Circle, Ellipse, Polygon, realize_geom
 from .utils import WIDE_MASK
 from .cat_healsparse_files import cat_healsparse_files

--- a/healsparse/geom.py
+++ b/healsparse/geom.py
@@ -136,6 +136,8 @@ class GeomBase(object):
         x = np.zeros(1, dtype=dtype)
         if is_integer_value(x[0]):
             sentinel = 0
+        elif dtype == np.bool_:
+            sentinel = False
         else:
             sentinel = hpg.UNSEEN
 

--- a/healsparse/geom.py
+++ b/healsparse/geom.py
@@ -176,7 +176,7 @@ class GeomBase(object):
         x = np.zeros(1, dtype=dtype)
         if is_integer_value(x[0]):
             sentinel = 0
-        elif dtype == np.bool_:
+        elif dtype == np.bool_ or dtype == bool:
             sentinel = False
         else:
             sentinel = hpg.UNSEEN

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -323,6 +323,16 @@ class GeomTestCase(unittest.TestCase):
         testing.assert_array_equal(smap.valid_pixels, smap2.valid_pixels)
         testing.assert_array_equal(smap2.get_values_pix(smap2.valid_pixels), 2.0)
 
+        # Test booleans
+        poly = Polygon(
+            ra=ra,
+            dec=dec,
+            value=True,
+        )
+        smap3 = poly.get_map(nside_coverage=32, nside_sparse=nside, dtype=np.bool_)
+        testing.assert_array_equal(smap.valid_pixels, smap3.valid_pixels)
+        testing.assert_array_equal(smap3.get_values_pix(smap3.valid_pixels), True)
+
     def test_polygon_nside_render(self):
         """Test using a polygon with a different rendering nside."""
         nside = 2**17

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -2,6 +2,7 @@ import unittest
 import numpy.testing as testing
 
 import numpy as np
+import hpgeom as hpg
 
 import healsparse
 from healsparse import Circle, Polygon, Ellipse
@@ -201,6 +202,45 @@ class GeomTestCase(unittest.TestCase):
             value=1.0,
         )
 
+    def test_circle_nside_render(self):
+        """Test using a circle with a different rendering nside."""
+        nside = 2**17
+
+        ra, dec = 200.0, 0.0
+        radius = 30.0/3600.0
+        nside_render = 2**14
+        circle = Circle(
+            ra=ra,
+            dec=dec,
+            radius=radius,
+            value=2**4,
+            nside_render=nside_render,
+        )
+
+        pixels = circle.get_pixels(nside=nside)
+
+        pixels_coarse = hpg.query_circle(nside_render, ra, dec, radius, inclusive=False)
+        pixels_fine = hpg.upgrade_pixels(nside_render, pixels_coarse, nside)
+
+        np.testing.assert_array_equal(pixels, pixels_fine)
+
+        pixel_ranges = circle.get_pixel_ranges(nside=nside)
+
+        pixel_ranges_coarse = hpg.query_circle(
+            nside_render,
+            ra,
+            dec,
+            radius,
+            inclusive=False,
+            return_pixel_ranges=True,
+        )
+        pixel_ranges_fine = hpg.upgrade_pixel_ranges(nside_render, pixel_ranges_coarse, nside)
+
+        np.testing.assert_array_equal(pixel_ranges, pixel_ranges_fine)
+
+        with self.assertRaises(ValueError):
+            circle.get_pixels(nside=2**10)
+
     def test_polygon_smoke(self):
         """
         just test we can make a polygon and a map from it
@@ -282,6 +322,47 @@ class GeomTestCase(unittest.TestCase):
         smap2 = poly.get_map(nside_coverage=32, nside_sparse=nside, dtype=np.float32)
         testing.assert_array_equal(smap.valid_pixels, smap2.valid_pixels)
         testing.assert_array_equal(smap2.get_values_pix(smap2.valid_pixels), 2.0)
+
+    def test_polygon_nside_render(self):
+        """Test using a polygon with a different rendering nside."""
+        nside = 2**17
+
+        # make a box
+        ra_range = 200.0, 200.1
+        dec_range = 0.1, 0.2
+
+        ra = [ra_range[0], ra_range[1], ra_range[1], ra_range[0]]
+        dec = [dec_range[0], dec_range[0], dec_range[1], dec_range[1]]
+        nside_render = 2**14
+        poly = Polygon(
+            ra=ra,
+            dec=dec,
+            value=64,
+            nside_render=nside_render,
+        )
+
+        pixels = poly.get_pixels(nside=nside)
+
+        pixels_coarse = hpg.query_polygon(nside_render, ra, dec, inclusive=False)
+        pixels_fine = hpg.upgrade_pixels(nside_render, pixels_coarse, nside)
+
+        np.testing.assert_array_equal(pixels, pixels_fine)
+
+        pixel_ranges = poly.get_pixel_ranges(nside=nside)
+
+        pixel_ranges_coarse = hpg.query_polygon(
+            nside_render,
+            ra,
+            dec,
+            inclusive=False,
+            return_pixel_ranges=True,
+        )
+        pixel_ranges_fine = hpg.upgrade_pixel_ranges(nside_render, pixel_ranges_coarse, nside)
+
+        np.testing.assert_array_equal(pixel_ranges, pixel_ranges_fine)
+
+        with self.assertRaises(ValueError):
+            poly.get_pixels(nside=2**10)
 
     def test_ellipse_smoke(self):
         """
@@ -374,6 +455,59 @@ class GeomTestCase(unittest.TestCase):
         smap2 = ellipse.get_map(nside_coverage=32, nside_sparse=nside, dtype=np.float32)
         testing.assert_array_equal(smap.valid_pixels, smap2.valid_pixels)
         testing.assert_array_equal(smap2.get_values_pix(smap2.valid_pixels), 2.0)
+
+    def test_ellipse_render(self):
+        """Test using an ellipse with a different rendering nside."""
+        nside = 2**17
+
+        ra, dec = 200.0, 0.0
+        semi_major = 30.0/3600.0
+        semi_minor = 15.0/3600.0
+        alpha = 45.0
+        nside_render = 2**14
+        ellipse = Ellipse(
+            ra=ra,
+            dec=dec,
+            semi_major=semi_major,
+            semi_minor=semi_minor,
+            alpha=alpha,
+            value=2**4,
+            nside_render=nside_render,
+        )
+
+        pixels = ellipse.get_pixels(nside=nside)
+
+        pixels_coarse = hpg.query_ellipse(
+            nside_render,
+            ra,
+            dec,
+            semi_major,
+            semi_minor,
+            alpha,
+            inclusive=False,
+        )
+        pixels_fine = hpg.upgrade_pixels(nside_render, pixels_coarse, nside)
+
+        np.testing.assert_array_equal(pixels, pixels_fine)
+
+        pixel_ranges = ellipse.get_pixel_ranges(nside=nside)
+
+        pixel_ranges_coarse = hpg.query_ellipse(
+            nside_render,
+            ra,
+            dec,
+            semi_major,
+            semi_minor,
+            alpha,
+            inclusive=False,
+            return_pixel_ranges=True,
+        )
+        pixel_ranges_fine = hpg.upgrade_pixel_ranges(nside_render, pixel_ranges_coarse, nside)
+
+        np.testing.assert_array_equal(pixel_ranges, pixel_ranges_fine)
+
+        with self.assertRaises(ValueError):
+            ellipse.get_pixels(nside=2**10)
 
     def test_realize_geom_or(self):
         """


### PR DESCRIPTION
This also fixes a bug when trying to use `get_map()` with a boolean map, and adds a `Box` geometry type with sides of constant ra/dec.