### PR TITLE
Fix crash when certain large geometries would cause coverage map to go out-of-bounds.

### DIFF
--- a/.github/workflows/python-package-pr.yml
+++ b/.github/workflows/python-package-pr.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        numpy-version: ["==1", "==2"]
 
     steps:
     - uses: actions/checkout@v3
@@ -26,7 +25,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[parquet,test,test_with_healpy]
-        pip install 'numpy{{ numpy-version }}'
     - name: Lint with flake8
       run: |
         flake8

--- a/.github/workflows/python-package-pr.yml
+++ b/.github/workflows/python-package-pr.yml
@@ -25,7 +25,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[parquet,test,test_with_healpy] "numpy{{ matrix.numpy-version }}"
+        pip install .[parquet,test,test_with_healpy]
+        pip install 'numpy{{ numpy-version }}'
     - name: Lint with flake8
       run: |
         flake8

--- a/.github/workflows/python-package-pr.yml
+++ b/.github/workflows/python-package-pr.yml
@@ -13,7 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        numpy-version: ["==1", "==2"]
 
     steps:
     - uses: actions/checkout@v3
@@ -24,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[parquet,test,test_with_healpy]
+        pip install .[parquet,test,test_with_healpy] "numpy{{ matrix.numpy-version }}"
     - name: Lint with flake8
       run: |
         flake8

--- a/.github/workflows/python-package-publish.yml
+++ b/.github/workflows/python-package-publish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           cache: "pip"
           cache-dependency-path: "setup.cfg"
 
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           cache: "pip"
           cache-dependency-path: "setup.cfg"
 

--- a/.github/workflows/python-package-push.yml
+++ b/.github/workflows/python-package-push.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -553,15 +553,15 @@ class HealSparseMap(object):
                     if not self.is_integer_map:
                         raise ValueError("Cannot set non-integer map with an integer")
                     is_single_value = True
-                    _values = np.array([values], dtype=self.dtype)
+                    _values = np.asarray([values], dtype=self.dtype)
                 elif isinstance(values, numbers.Real):
                     if self.is_integer_map:
                         raise ValueError("Cannot set non-floating point map with a floating point.")
                     is_single_value = True
-                    _values = np.array([values], dtype=self.dtype)
+                    _values = np.asarray([values], dtype=self.dtype)
                 elif isinstance(values, (bool, np.bool_)):
                     is_single_value = True
-                    _values = np.array([values], dtype=bool)
+                    _values = np.asarray([values], dtype=bool)
 
         if isinstance(values, np.ndarray) and len(values) == 1:
             is_single_value = True
@@ -885,7 +885,7 @@ class HealSparseMap(object):
             if self._is_wide_mask:
                 return np.zeros((0, self._wide_mask_width), dtype=self.dtype)
             else:
-                return np.array([], dtype=self.dtype)
+                return np.asarray([], dtype=self.dtype)
 
         if not nest:
             _pix = hpg.ring_to_nest(self._nside_sparse, pixels)
@@ -1347,7 +1347,7 @@ class HealSparseMap(object):
         elif self._is_bit_packed:
             # This is dangerous because it expands into a full array first; this
             # can blow up memory.
-            valid_pixel_inds, = np.where(np.array(self._sparse_map) != self._sentinel)
+            valid_pixel_inds, = np.where(np.asarray(self._sparse_map) != self._sentinel)
         else:
             valid_pixel_inds, = np.where(self._sparse_map != self._sentinel)
 
@@ -1446,7 +1446,7 @@ class HealSparseMap(object):
         """
         # Check if this is in the coverage mask.
         if not self.coverage_mask[cov_pix]:
-            return np.array([], dtype=np.int64)
+            return np.asarray([], dtype=np.int64)
 
         # This is the start of the coverage pixel slice.
         start = (self._cov_map[cov_pix] +
@@ -1458,7 +1458,7 @@ class HealSparseMap(object):
         elif self._is_wide_mask:
             valid_pixel_inds, = np.where(np.any(self._sparse_map[s, :] != self._sentinel, axis=1))
         elif self._is_bit_packed:
-            valid_pixel_inds, = np.where(np.array(self._sparse_map[s]) != self._sentinel)
+            valid_pixel_inds, = np.where(np.asarray(self._sparse_map[s]) != self._sentinel)
         else:
             valid_pixel_inds, = np.where(self._sparse_map[s] != self._sentinel)
 
@@ -1829,7 +1829,7 @@ class HealSparseMap(object):
         elif isinstance(key, numbers.Integral):
             # Get a single pixel
             # Return a single (non-array) value
-            return self.get_values_pix(np.array([key]))[0]
+            return self.get_values_pix(np.asarray([key]))[0]
         elif isinstance(key, slice):
             # Get a slice of pixels
             start = key.start if key.start is not None else 0
@@ -1859,7 +1859,7 @@ class HealSparseMap(object):
         """
         if isinstance(key, numbers.Integral):
             # Set a single pixel
-            return self.update_values_pix(np.array([key]), value)
+            return self.update_values_pix(np.asarray([key]), value)
         elif isinstance(key, slice):
             # Set a slice of pixels
             start = key.start if key.start is not None else 0
@@ -2525,7 +2525,7 @@ class HealSparseMap(object):
                     rhs = _PackedBoolArray.from_boolean_array(other._sparse_map[start_other: end_other])
                 elif not self._is_bit_packed and other._is_bit_packed:
                     # Expand the RHS to a regular boolean array.
-                    rhs = np.array(other._sparse_map[start_other: end_other])
+                    rhs = np.asarray(other._sparse_map[start_other: end_other])
 
                 if name == "and":
                     lhs &= rhs

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -695,6 +695,10 @@ class HealSparseMap(object):
         # Compute the coverage pixels.
         cov_pix_ranges = np.right_shift(pixel_ranges, self._cov_map.bit_shift)
         # After the bit shift these pixel ranges are inclusive, not exclusive.
+        # But we also need to protect against an overrun at the high end.
+        if cov_pix_ranges[-1, 1] == len(self.coverage_mask):
+            cov_pix_ranges[-1, 1] = len(self.coverage_mask) - 1
+
         cov_pix_to_set = hpg.pixel_ranges_to_pixels(cov_pix_ranges, inclusive=True)
         cov_pix_to_set = np.unique(cov_pix_to_set)
 

--- a/healsparse/io_map_fits.py
+++ b/healsparse/io_map_fits.py
@@ -390,7 +390,7 @@ def _read_healsparse_fits_file_and_degrade(filename, pixels, nside_out, reductio
         if cov_map_weight.nside_coverage != cov_map.nside_coverage:
             raise ValueError("The weightfile %s must have same coverage nside." % (weightfile))
         cov_pix_weight, = np.where(cov_map_weight.coverage_mask)
-        if not np.all(np.in1d(_pixels, cov_pix_weight)):
+        if not np.all(np.isin(_pixels, cov_pix_weight)):
             raise ValueError("The weightfile %s must have coverage in all the "
                              "pixels to read." % (weightfile))
         use_weightfile = True

--- a/tests/test_applymask.py
+++ b/tests/test_applymask.py
@@ -83,7 +83,7 @@ class ApplyMaskTestCase(unittest.TestCase):
         # Pixels that are in the original but are not in the masked pixels should be 1
         testing.assert_array_equal(int_map.get_values_pix(valid_pixels[still_good0]), 1)
 
-    def test_apply_mask_float(self):
+    def test_apply_mask_float32(self):
         """
         Test apply_mask on a float map
         """
@@ -119,8 +119,9 @@ class ApplyMaskTestCase(unittest.TestCase):
         masked_map = float_map.apply_mask(mask_map, in_place=False)
         masked_pixels = mask_map.valid_pixels
 
-        # Masked pixels should be zero
-        testing.assert_almost_equal(masked_map.get_values_pix(masked_pixels), hpg.UNSEEN)
+        # Masked pixels should be UNSEEN
+        delta = masked_map.get_values_pix(masked_pixels) - hpg.UNSEEN
+        testing.assert_array_almost_equal(delta, 0.0)
 
         # Pixels that are in the original but are not in the masked pixels should be 1
         still_good0, = np.where((float_map.get_values_pix(valid_pixels) > hpg.UNSEEN) &
@@ -134,8 +135,9 @@ class ApplyMaskTestCase(unittest.TestCase):
         masked_map = float_map.apply_mask(mask_map, mask_bits=4, in_place=False)
         masked_pixels = mask_map.valid_pixels
 
-        # Masked pixels should be zero
-        testing.assert_almost_equal(masked_map.get_values_pix(masked_pixels), hpg.UNSEEN)
+        # Masked pixels should be UNSEEN
+        delta = masked_map.get_values_pix(masked_pixels) - hpg.UNSEEN
+        testing.assert_array_almost_equal(delta, 0.0)
 
         # Pixels that are in the original but are not in the masked pixels should be 1
         still_good, = np.where((float_map.get_values_pix(valid_pixels) > 0) &
@@ -157,8 +159,9 @@ class ApplyMaskTestCase(unittest.TestCase):
         float_map.apply_mask(mask_map, in_place=True)
         masked_pixels = mask_map.valid_pixels
 
-        # Masked pixels should be zero
-        testing.assert_almost_equal(float_map.get_values_pix(masked_pixels), hpg.UNSEEN)
+        # Masked pixels should be UNSEEN
+        delta = float_map.get_values_pix(masked_pixels) - hpg.UNSEEN
+        testing.assert_array_almost_equal(delta, 0.0)
 
         # Pixels that are in the original but are not in the masked pixels should be 1
         testing.assert_almost_equal(float_map.get_values_pix(valid_pixels[still_good0]), 1.0)

--- a/tests/test_astype.py
+++ b/tests/test_astype.py
@@ -62,8 +62,8 @@ class AstypeCase(unittest.TestCase):
         testing.assert_array_equal(sparse_map.valid_pixels, sparse_map_float.valid_pixels)
         testing.assert_array_almost_equal(sparse_map[sparse_map.valid_pixels],
                                           sparse_map_float[sparse_map.valid_pixels])
-        testing.assert_array_equal(sparse_map_float._sparse_map[0: nfine_per_cov],
-                                   hpg.UNSEEN)
+        delta = sparse_map_float._sparse_map[0: nfine_per_cov] - hpg.UNSEEN
+        testing.assert_array_almost_equal(delta, 0.0)
 
         # Convert to a float map with 0 sentinel
         sparse_map_float2 = sparse_map.astype(np.float32, sentinel=0.0)
@@ -132,8 +132,8 @@ class AstypeCase(unittest.TestCase):
         testing.assert_array_equal(sparse_map.valid_pixels, sparse_map_float.valid_pixels)
         testing.assert_array_almost_equal(sparse_map[sparse_map.valid_pixels],
                                           sparse_map_float[sparse_map.valid_pixels])
-        testing.assert_array_equal(sparse_map_float._sparse_map[0: nfine_per_cov],
-                                   hpg.UNSEEN)
+        delta = sparse_map_float._sparse_map[0: nfine_per_cov] - hpg.UNSEEN
+        testing.assert_array_almost_equal(delta, 0.0)
 
         # Convert to a different float map with 0 sentinel
         sparse_map_float2 = sparse_map.astype(np.float32, sentinel=0.0)

--- a/tests/test_buildmaps.py
+++ b/tests/test_buildmaps.py
@@ -111,8 +111,9 @@ class BuildMapsTestCase(unittest.TestCase):
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, dtype, primary='col1')
 
         # Look up all the values, make sure they're all UNSEEN
-        testing.assert_almost_equal(sparse_map.get_values_pos(ra, dec, lonlat=True)['col1'], hpg.UNSEEN)
-        testing.assert_almost_equal(sparse_map.get_values_pos(ra, dec, lonlat=True)['col2'], hpg.UNSEEN)
+        delta = sparse_map.get_values_pos(ra, dec, lonlat=True)['col1'] - hpg.UNSEEN
+        testing.assert_array_almost_equal(delta, 0.0)
+        testing.assert_array_almost_equal(sparse_map.get_values_pos(ra, dec, lonlat=True)['col2'], hpg.UNSEEN)
 
         pixel = np.arange(4000, 20000)
         values = np.zeros_like(pixel, dtype=dtype)

--- a/tests/test_cat_files.py
+++ b/tests/test_cat_files.py
@@ -31,7 +31,7 @@ class CatFilesTestCase(unittest.TestCase):
                 primary = None
                 wide_mask_maxbits = None
                 sentinel = hpg.UNSEEN
-                data = np.array([100.0], dtype=dtype)
+                data = np.asarray([100.0], dtype=dtype)
             elif t == 'recarray':
                 dtype = [('a', 'f4'),
                          ('b', 'i4')]
@@ -137,7 +137,7 @@ class CatFilesTestCase(unittest.TestCase):
                 primary = None
                 wide_mask_maxbits = None
                 sentinel = -9999
-                data = np.array([100.0], dtype=dtype)
+                data = np.asarray([100.0], dtype=dtype)
             elif t == 'recarray':
                 dtype = [('a', 'f4'),
                          ('b', 'i4')]
@@ -187,11 +187,11 @@ class CatFilesTestCase(unittest.TestCase):
                                                                     sentinel=sentinel)
             if combined_map.is_integer_map:
                 combined_map[map1.valid_pixels] = map1[map1.valid_pixels]
-                overlap = np.in1d(map2.valid_pixels, combined_map.valid_pixels)
+                overlap = np.isin(map2.valid_pixels, combined_map.valid_pixels)
                 combined_map[map2.valid_pixels[overlap]] = map2[map2.valid_pixels[overlap]] | \
                     combined_map[map2.valid_pixels[overlap]]
                 combined_map[map2.valid_pixels[~overlap]] = map2[map2.valid_pixels[~overlap]]
-                overlap = np.in1d(map3.valid_pixels, combined_map.valid_pixels)
+                overlap = np.isin(map3.valid_pixels, combined_map.valid_pixels)
                 combined_map[map3.valid_pixels[overlap]] = map3[map3.valid_pixels[overlap]] | \
                     combined_map[map3.valid_pixels[overlap]]
                 combined_map[map3.valid_pixels[~overlap]] = map3[map3.valid_pixels[~overlap]]

--- a/tests/test_degrade.py
+++ b/tests/test_degrade.py
@@ -220,7 +220,7 @@ class DegradeMapTestCase(unittest.TestCase):
         sparse_map_or.set_bits_pix(pixel2_all, [4, 12])
 
         # Get the pixel number of the bad pixels
-        pixel2_bad = np.array([0])
+        pixel2_bad = np.asarray([0])
         sparse_map_or.clear_bits_pix(pixel2_bad, [4])  # set low value in the first pixel
 
         # Degrade with or

--- a/tests/test_emptypixels.py
+++ b/tests/test_emptypixels.py
@@ -14,10 +14,10 @@ class EmptyPixelsTestCase(unittest.TestCase):
         m = healsparse.HealSparseMap.make_empty(32, 512, np.float32)
         m[1000] = 1.0
 
-        empty_arr = np.array([], dtype=m.dtype)
+        empty_arr = np.asarray([], dtype=m.dtype)
 
         testing.assert_array_equal(m.get_values_pix([]), empty_arr)
-        testing.assert_array_equal(m.get_values_pix(np.array([], dtype=np.int64)), empty_arr)
+        testing.assert_array_equal(m.get_values_pix(np.asarray([], dtype=np.int64)), empty_arr)
 
     def test_emptypixels_get_values_widemask(self):
         """
@@ -33,10 +33,10 @@ class EmptyPixelsTestCase(unittest.TestCase):
         m = healsparse.HealSparseMap.make_empty(32, 512, np.float64)
         m[1000] = 1.0
 
-        empty_arr = np.array([], dtype=m.dtype)
+        empty_arr = np.asarray([], dtype=m.dtype)
 
         testing.assert_array_equal(m[[]], empty_arr)
-        testing.assert_array_equal(m[np.array([], dtype=np.int64)], empty_arr)
+        testing.assert_array_equal(m[np.asarray([], dtype=np.int64)], empty_arr)
 
     def test_emptypixels_get_by_index_widemask(self):
         """
@@ -52,7 +52,7 @@ class EmptyPixelsTestCase(unittest.TestCase):
         m = healsparse.HealSparseMap.make_empty(32, 512, np.float64)
         m[1000] = 1.0
 
-        empty_arr = np.array([], dtype=m.dtype)
+        empty_arr = np.asarray([], dtype=m.dtype)
 
         testing.assert_array_equal(m[0: 0], empty_arr)
 
@@ -70,23 +70,23 @@ class EmptyPixelsTestCase(unittest.TestCase):
         m = healsparse.HealSparseMap.make_empty(32, 512, np.int64)
         m[1000] = 1
 
-        m.update_values_pix([], np.array([], dtype=np.int64))
+        m.update_values_pix([], np.asarray([], dtype=np.int64))
         self.assertEqual(m[1000], 1)
         self.assertEqual(len(m.valid_pixels), 1)
 
-        m.update_values_pix(np.array([], dtype=np.int32), np.array([], dtype=np.int64))
+        m.update_values_pix(np.asarray([], dtype=np.int32), np.asarray([], dtype=np.int64))
         self.assertEqual(m[1000], 1)
         self.assertEqual(len(m.valid_pixels), 1)
 
-        m.update_values_pix([], np.array([], dtype=np.int64))
+        m.update_values_pix([], np.asarray([], dtype=np.int64))
         m.update_values_pix([], 5)
 
         self.assertWarns(UserWarning, m.update_values_pix, [], np.zeros(5, dtype=m.dtype))
 
         m.update_values_pos(
-            np.array([], dtype=np.float64),
-            np.array([], dtype=np.float64),
-            np.array([], dtype=np.int64),
+            np.asarray([], dtype=np.float64),
+            np.asarray([], dtype=np.float64),
+            np.asarray([], dtype=np.int64),
         )
 
     def test_emptypixels_set_by_index(self):
@@ -96,15 +96,15 @@ class EmptyPixelsTestCase(unittest.TestCase):
         m = healsparse.HealSparseMap.make_empty(32, 512, np.int32)
         m[1000] = 1
 
-        m[[]] = np.array([], dtype=np.int32)
+        m[[]] = np.asarray([], dtype=np.int32)
         self.assertEqual(m[1000], 1)
         self.assertEqual(len(m.valid_pixels), 1)
 
-        m[np.array([], dtype=np.int32)] = np.array([], dtype=np.int32)
+        m[np.asarray([], dtype=np.int32)] = np.asarray([], dtype=np.int32)
         self.assertEqual(m[1000], 1)
         self.assertEqual(len(m.valid_pixels), 1)
 
-        m[[]] = np.array([], dtype=np.int32)
+        m[[]] = np.asarray([], dtype=np.int32)
         m[[]] = 0
 
         self.assertWarns(UserWarning, m.__setitem__, [], np.zeros(5, dtype=np.int32))

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -50,8 +50,8 @@ def _randcap(rng, nrand, ra, dec, rad, get_radius=False):
     # generate position angle uniformly 0,2*PI
     rand_posangle = rng.uniform(nrand)*2*np.pi
 
-    theta = np.array(dec, dtype='f8', ndmin=1, copy=True)
-    phi = np.array(ra, dtype='f8', ndmin=1, copy=True)
+    theta = np.atleast_1d(np.asarray(dec, dtype='f8').copy())
+    phi = np.atleast_1d(np.asarray(ra, dtype='f8').copy())
     theta += 90
 
     np.deg2rad(theta, theta)
@@ -258,8 +258,8 @@ class GeomTestCase(unittest.TestCase):
 
         smap = poly.get_map(nside_coverage=32, nside_sparse=nside, dtype=np.int16)
 
-        ra = np.array([200.1, 200.15])
-        dec = np.array([0.05, 0.015])
+        ra = np.asarray([200.1, 200.15])
+        dec = np.asarray([0.05, 0.015])
         vals = smap.get_values_pos(ra, dec, lonlat=True)
 
         testing.assert_array_equal(vals, [poly.value, 0])

--- a/tests/test_getset.py
+++ b/tests/test_getset.py
@@ -100,11 +100,11 @@ class GetSetTestCase(unittest.TestCase):
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
 
-        indices = np.array([1, 2, 100, 500, 10000])
+        indices = np.asarray([1, 2, 100, 500, 10000])
         testing.assert_array_almost_equal(sparse_map[indices], full_map[indices])
         testing.assert_almost_equal(sparse_map[indices[0]], full_map[indices[0]])
 
-        indices = np.array([1., 2, 100, 500, 10000])
+        indices = np.asarray([1., 2, 100, 500, 10000])
         self.assertRaises(IndexError, sparse_map.__getitem__, indices)
         self.assertRaises(IndexError, sparse_map.__getitem__, indices[0])
 
@@ -249,8 +249,8 @@ class GetSetTestCase(unittest.TestCase):
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
 
         # This needs to be accessed with an array of length 1 or same length.
-        sparse_map[100: 500] = np.array([1.0])
-        full_map[100: 500] = np.array([1.0])
+        sparse_map[100: 500] = np.asarray([1.0])
+        full_map[100: 500] = np.asarray([1.0])
         testing.assert_array_almost_equal(sparse_map.generate_healpix_map(),
                                           full_map)
 
@@ -279,8 +279,8 @@ class GetSetTestCase(unittest.TestCase):
         testing.assert_array_equal(sparse_map.coverage_mask, covmask_orig)
 
         # Test all
-        sparse_map[:] = np.array([1.0])
-        full_map[:] = np.array([1.0])
+        sparse_map[:] = np.asarray([1.0])
+        full_map[:] = np.asarray([1.0])
         testing.assert_array_almost_equal(sparse_map.generate_healpix_map(),
                                           full_map)
 
@@ -298,9 +298,9 @@ class GetSetTestCase(unittest.TestCase):
 
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
 
-        indices = np.array([1, 2, 100, 500, 10000])
-        sparse_map[indices] = np.array([1.0])
-        full_map[indices] = np.array([1.0])
+        indices = np.asarray([1, 2, 100, 500, 10000])
+        sparse_map[indices] = np.asarray([1.0])
+        full_map[indices] = np.asarray([1.0])
         testing.assert_array_almost_equal(sparse_map.generate_healpix_map(),
                                           full_map)
 
@@ -310,13 +310,13 @@ class GetSetTestCase(unittest.TestCase):
         testing.assert_array_almost_equal(sparse_map.generate_healpix_map(),
                                           full_map)
 
-        indices = np.array([1, 2, 100, 500, 10000]) + 100
+        indices = np.asarray([1, 2, 100, 500, 10000]) + 100
         sparse_map[indices] = np.ones(len(indices))
         full_map[indices] = np.ones(len(indices))
         testing.assert_array_almost_equal(sparse_map.generate_healpix_map(),
                                           full_map)
 
-        indices = np.array([1., 2, 100, 500, 10000])
+        indices = np.asarray([1., 2, 100, 500, 10000])
         self.assertRaises(IndexError, sparse_map.__setitem__, indices, 1.0)
 
     def test_setitem_list(self):
@@ -334,8 +334,8 @@ class GetSetTestCase(unittest.TestCase):
         sparse_map = healsparse.HealSparseMap(healpix_map=full_map, nside_coverage=nside_coverage)
 
         indices = [1, 2, 100, 500, 10000]
-        sparse_map[indices] = np.array([1.0])
-        full_map[indices] = np.array([1.0])
+        sparse_map[indices] = np.asarray([1.0])
+        full_map[indices] = np.asarray([1.0])
         testing.assert_array_almost_equal(sparse_map.generate_healpix_map(),
                                           full_map)
 

--- a/tests/test_packedboolarray.py
+++ b/tests/test_packedboolarray.py
@@ -94,19 +94,19 @@ class PackedBoolArrayTestCase(unittest.TestCase):
         # Create specifying nothing, should be 0 size.
         pba = _PackedBoolArray()
         self.assertEqual(pba.size, 0)
-        testing.assert_array_equal(np.array(pba), np.zeros(0, dtype=np.bool_))
+        testing.assert_array_equal(np.asarray(pba), np.zeros(0, dtype=np.bool_))
 
         # Specify a few sizes.
         for size in range(128):
             pba = _PackedBoolArray(size=size)
             self.assertEqual(pba.size, size)
-            testing.assert_array_equal(np.array(pba), np.zeros(size, dtype=np.bool_))
+            testing.assert_array_equal(np.asarray(pba), np.zeros(size, dtype=np.bool_))
 
         # Specify a few sizes with an offset.
         for size in range(128):
             pba = _PackedBoolArray(size=size, start_index=2)
             self.assertEqual(pba.size, size)
-            testing.assert_array_equal(np.array(pba), np.zeros(size, dtype=np.bool_))
+            testing.assert_array_equal(np.asarray(pba), np.zeros(size, dtype=np.bool_))
 
         with self.assertRaises(ValueError):
             pba = _PackedBoolArray(size=10, data_buffer=np.zeros(5, dtype=np.uint8))
@@ -135,7 +135,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
             data_buffer = np.zeros(size // 8, dtype=np.uint8)
             pba = _PackedBoolArray(data_buffer=data_buffer)
             self.assertEqual(pba.size, size)
-            testing.assert_array_equal(np.array(pba), np.zeros(size, dtype=np.bool_))
+            testing.assert_array_equal(np.asarray(pba), np.zeros(size, dtype=np.bool_))
 
         # If we want a specific size, we must also specify the stop index.
         for size in range(0, 128, 8):
@@ -147,21 +147,21 @@ class PackedBoolArrayTestCase(unittest.TestCase):
                     stop_index=start_index + size,
                 )
                 self.assertEqual(pba.size, size)
-                testing.assert_array_equal(np.array(pba), np.zeros(size, dtype=np.bool_))
+                testing.assert_array_equal(np.asarray(pba), np.zeros(size, dtype=np.bool_))
 
     def test_create_from_bool_array(self):
         for size in range(128):
             arr = np.ones(size, dtype=np.bool_)
             pba = _PackedBoolArray.from_boolean_array(arr)
             self.assertEqual(pba.size, size)
-            testing.assert_array_equal(np.array(pba), arr)
+            testing.assert_array_equal(np.asarray(pba), arr)
 
         for size in range(128):
             for start_index in range(0, 8):
                 arr = np.ones(size, dtype=np.bool_)
                 pba = _PackedBoolArray.from_boolean_array(arr, start_index=start_index)
                 self.assertEqual(pba.size, size)
-                testing.assert_array_equal(np.array(pba), arr)
+                testing.assert_array_equal(np.asarray(pba), arr)
 
         with self.assertRaises(NotImplementedError):
             pba = _PackedBoolArray.from_boolean_array(7)
@@ -179,7 +179,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
             self.assertEqual(pba.size, newsize)
             comp_array = np.zeros(newsize, dtype=np.bool_)
             comp_array[[0, 4, 6]] = True
-            testing.assert_array_equal(np.array(pba), comp_array)
+            testing.assert_array_equal(np.asarray(pba), comp_array)
 
         for newsize in range(16, 128):
             for start_index in range(8):
@@ -191,7 +191,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
                 self.assertEqual(pba.size, newsize)
                 comp_array = np.zeros(newsize, dtype=np.bool_)
                 comp_array[[0, 4, 6]] = True
-                testing.assert_array_equal(np.array(pba), comp_array)
+                testing.assert_array_equal(np.asarray(pba), comp_array)
 
         with self.assertRaises(ValueError):
             pba = _PackedBoolArray(size=10)
@@ -208,9 +208,9 @@ class PackedBoolArrayTestCase(unittest.TestCase):
 
             for pba in pba_arrays:
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
-                testing.assert_array_equal(np.array(pba_test), pba_array)
+                testing.assert_array_equal(np.asarray(pba_test), pba_array)
                 self.assertEqual(pba_test._start_index, pba._start_index)
                 self.assertEqual(pba_test._stop_index, pba._stop_index)
 
@@ -234,7 +234,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
                 pba_arrays = self._make_long_arrays()
 
             for pba in pba_arrays:
-                self.assertEqual(pba.sum(), np.array(pba).sum())
+                self.assertEqual(pba.sum(), np.asarray(pba).sum())
 
         # Do sums over aligned arrays, with and without reshaping.
         for mode in ("short", "middle", "long"):
@@ -248,13 +248,13 @@ class PackedBoolArrayTestCase(unittest.TestCase):
             shape = (pba.size // 8, 8)
             testing.assert_array_equal(
                 pba.sum(shape=shape),
-                np.array(pba).reshape(shape).sum(),
+                np.asarray(pba).reshape(shape).sum(),
             )
 
             shape = (pba.size // 8, 8)
             testing.assert_array_equal(
                 pba.sum(shape=shape, axis=1),
-                np.array(pba).reshape(shape).sum(axis=1),
+                np.asarray(pba).reshape(shape).sum(axis=1),
             )
 
         with self.assertRaises(ValueError):
@@ -321,7 +321,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
         for pba in short_arrays:
             # Test setting a single index to True or False.
             pba_test = pba.copy()
-            pba_array = np.array(pba)
+            pba_array = np.asarray(pba)
 
             pba_test[2] = True
             pba_array[2] = True
@@ -334,34 +334,34 @@ class PackedBoolArrayTestCase(unittest.TestCase):
 
             # Test setting a list/array of indexes to True or False.
             pba_test = pba.copy()
-            pba_array = np.array(pba)
+            pba_array = np.asarray(pba)
 
             pba_test[[1, 2, 4]] = True
             pba_array[[1, 2, 4]] = True
             testing.assert_array_equal(pba_test, pba_array)
 
-            pba_test[np.array([1, 2, 4])] = False
-            pba_array[np.array([1, 2, 4])] = False
+            pba_test[np.asarray([1, 2, 4])] = False
+            pba_array[np.asarray([1, 2, 4])] = False
             testing.assert_array_equal(pba_test, pba_array)
 
-            pba_test[np.array([], dtype=np.int64)] = True
+            pba_test[np.asarray([], dtype=np.int64)] = True
             testing.assert_array_equal(pba_test, pba_array)
 
-            pba_test[np.array([], dtype=np.int64)] = False
+            pba_test[np.asarray([], dtype=np.int64)] = False
             testing.assert_array_equal(pba_test, pba_array)
 
             # Test setting a list/array of indices to an array.
             pba_test = pba.copy()
-            pba_array = np.array(pba)
+            pba_array = np.asarray(pba)
 
-            pba_test[[1, 2, 4]] = np.array([True, True, False])
-            pba_array[[1, 2, 4]] = np.array([True, True, False])
+            pba_test[[1, 2, 4]] = np.asarray([True, True, False])
+            pba_array[[1, 2, 4]] = np.asarray([True, True, False])
             testing.assert_array_equal(pba_test, pba_array)
 
             # Test setting slices: setting to True/False
             for full in (True, False):
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 if full:
                     s = slice(None, None, None)
@@ -379,7 +379,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
             # Test setting slices: setting to a numpy array.
             for full in (True, False):
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 if full:
                     s = slice(None, None, None)
@@ -394,7 +394,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
             # Test setting slices: setting to packed boolean array.
             for full in (True, False):
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 if full:
                     s = slice(None, None, None)
@@ -408,7 +408,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
                 target[:] = True
 
                 pba_test[s] = target
-                pba_array[s] = np.array(target)
+                pba_array[s] = np.asarray(target)
                 testing.assert_array_equal(pba_test, pba_array)
 
         with self.assertRaises(ValueError):
@@ -441,7 +441,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
         for pba in middle_arrays:
             # Test setting a single index to True or False.
             pba_test = pba.copy()
-            pba_array = np.array(pba)
+            pba_array = np.asarray(pba)
 
             pba_test[10] = True
             pba_array[10] = True
@@ -454,28 +454,28 @@ class PackedBoolArrayTestCase(unittest.TestCase):
 
             # Test setting a list/array of indexes to True or False.
             pba_test = pba.copy()
-            pba_array = np.array(pba)
+            pba_array = np.asarray(pba)
 
             pba_test[[1, 2, 4, 10]] = True
             pba_array[[1, 2, 4, 10]] = True
             testing.assert_array_equal(pba_test, pba_array)
 
-            pba_test[np.array([1, 2, 4, 10])] = False
-            pba_array[np.array([1, 2, 4, 10])] = False
+            pba_test[np.asarray([1, 2, 4, 10])] = False
+            pba_array[np.asarray([1, 2, 4, 10])] = False
             testing.assert_array_equal(pba_test, pba_array)
 
             # Test setting a list/array of indices to an array.
             pba_test = pba.copy()
-            pba_array = np.array(pba)
+            pba_array = np.asarray(pba)
 
-            pba_test[[1, 2, 4, 10]] = np.array([True, True, False, False])
-            pba_array[[1, 2, 4, 10]] = np.array([True, True, False, False])
+            pba_test[[1, 2, 4, 10]] = np.asarray([True, True, False, False])
+            pba_array[[1, 2, 4, 10]] = np.asarray([True, True, False, False])
             testing.assert_array_equal(pba_test, pba_array)
 
             # Test setting slices: setting to True/False
             for full in (True, False):
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 if full:
                     s = slice(None, None, None)
@@ -493,7 +493,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
             # Test setting slices: setting to a numpy array.
             for full in (True, False):
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 if full:
                     s = slice(None, None, None)
@@ -508,7 +508,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
             # Test setting slices: setting to packed boolean array.
             for full in (True, False):
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 if full:
                     s = slice(None, None, None)
@@ -521,7 +521,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
                 target[:] = True
 
                 pba_test[s] = target
-                pba_array[s] = np.array(target)
+                pba_array[s] = np.asarray(target)
                 testing.assert_array_equal(pba_test, pba_array)
 
     def test_setitem_long(self):
@@ -530,7 +530,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
         for pba in long_arrays:
             # Test setting a single index to True or False.
             pba_test = pba.copy()
-            pba_array = np.array(pba)
+            pba_array = np.asarray(pba)
 
             pba_test[20] = True
             pba_array[20] = True
@@ -543,28 +543,28 @@ class PackedBoolArrayTestCase(unittest.TestCase):
 
             # Test setting a list/array of indexes to True or False.
             pba_test = pba.copy()
-            pba_array = np.array(pba)
+            pba_array = np.asarray(pba)
 
             pba_test[[1, 2, 4, 10, 20, 29]] = True
             pba_array[[1, 2, 4, 10, 20, 29]] = True
             testing.assert_array_equal(pba_test, pba_array)
 
-            pba_test[np.array([1, 2, 4, 10, 20, 29])] = False
-            pba_array[np.array([1, 2, 4, 10, 20, 29])] = False
+            pba_test[np.asarray([1, 2, 4, 10, 20, 29])] = False
+            pba_array[np.asarray([1, 2, 4, 10, 20, 29])] = False
             testing.assert_array_equal(pba_test, pba_array)
 
             # Test setting a list/array of indices to an array.
             pba_test = pba.copy()
-            pba_array = np.array(pba)
+            pba_array = np.asarray(pba)
 
-            pba_test[[1, 2, 4, 10, 20, 29]] = np.array([True, True, False, False, False, True])
-            pba_array[[1, 2, 4, 10, 20, 29]] = np.array([True, True, False, False, False, True])
+            pba_test[[1, 2, 4, 10, 20, 29]] = np.asarray([True, True, False, False, False, True])
+            pba_array[[1, 2, 4, 10, 20, 29]] = np.asarray([True, True, False, False, False, True])
             testing.assert_array_equal(pba_test, pba_array)
 
             # Test setting slices: setting to True/False
             for mode in ("full", "aligned", "unaligned"):
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 if mode == "full":
                     s = slice(None, None, None)
@@ -584,7 +584,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
             # Test setting slices: setting to a numpy array.
             for mode in ("full", "aligned", "unaligned"):
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 if mode == "full":
                     s = slice(None, None, None)
@@ -602,7 +602,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
             for mode in ("full", "aligned", "unaligned"):
 
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 if mode == "full":
                     s = slice(None, None, None)
@@ -617,7 +617,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
                 target[:] = True
 
                 pba_test[s] = target
-                pba_array[s] = np.array(target)
+                pba_array[s] = np.asarray(target)
                 testing.assert_array_equal(pba_test, pba_array)
 
     def test_getitem_short(self):
@@ -625,26 +625,26 @@ class PackedBoolArrayTestCase(unittest.TestCase):
 
         for pba in short_arrays:
             # Test getting a single index.
-            arr = np.array(pba)
+            arr = np.asarray(pba)
             for i in range(len(pba)):
                 self.assertEqual(pba[i], arr[i])
 
             # Test getting slices.
             # The full slice.
-            testing.assert_array_equal(np.array(pba[:]), arr[:])
-            testing.assert_array_equal(np.array(pba[0: len(pba)]), arr[0: len(pba)])
+            testing.assert_array_equal(np.asarray(pba[:]), arr[:])
+            testing.assert_array_equal(np.asarray(pba[0: len(pba)]), arr[0: len(pba)])
 
             # Start at 0, end at less than the last:
-            testing.assert_array_equal(np.array(pba[: len(pba) - 2]), arr[: len(pba) - 2])
-            testing.assert_array_equal(np.array(pba[0: len(pba) - 2]), arr[0: len(pba) - 2])
+            testing.assert_array_equal(np.asarray(pba[: len(pba) - 2]), arr[: len(pba) - 2])
+            testing.assert_array_equal(np.asarray(pba[0: len(pba) - 2]), arr[0: len(pba) - 2])
 
             # Start at 1, end at end:
-            testing.assert_array_equal(np.array(pba[1:]), arr[1:])
-            testing.assert_array_equal(np.array(pba[1: len(pba)]), arr[1: len(pba)])
+            testing.assert_array_equal(np.asarray(pba[1:]), arr[1:])
+            testing.assert_array_equal(np.asarray(pba[1: len(pba)]), arr[1: len(pba)])
 
             # Start at 1, end at less than the last:
-            testing.assert_array_equal(np.array(pba[1: len(pba) - 2]), arr[1: len(pba) - 2])
-            testing.assert_array_equal(np.array(pba[1: -2]), arr[1: -2])
+            testing.assert_array_equal(np.asarray(pba[1: len(pba) - 2]), arr[1: len(pba) - 2])
+            testing.assert_array_equal(np.asarray(pba[1: -2]), arr[1: -2])
 
             # And get an array of indices:
             inds = np.arange(len(pba))
@@ -652,7 +652,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
             testing.assert_array_equal(pba[list(inds)], arr[list(inds)])
 
             # And an empty array of indices.
-            inds = np.array([], dtype=np.int64)
+            inds = np.asarray([], dtype=np.int64)
             testing.assert_array_equal(pba[inds], arr[inds])
 
         with self.assertRaises(IndexError):
@@ -680,34 +680,34 @@ class PackedBoolArrayTestCase(unittest.TestCase):
 
         for pba in middle_arrays:
             # Test getting a single index.
-            arr = np.array(pba)
+            arr = np.asarray(pba)
             for i in range(len(pba)):
                 self.assertEqual(pba[i], arr[i])
 
             # Test getting slices.
             # The full slice.
-            testing.assert_array_equal(np.array(pba[:]), arr[:])
-            testing.assert_array_equal(np.array(pba[0: len(pba)]), arr[0: len(pba)])
+            testing.assert_array_equal(np.asarray(pba[:]), arr[:])
+            testing.assert_array_equal(np.asarray(pba[0: len(pba)]), arr[0: len(pba)])
 
             # Start at 0, end at less than the last:
-            testing.assert_array_equal(np.array(pba[: len(pba) - 2]), arr[: len(pba) - 2])
-            testing.assert_array_equal(np.array(pba[0: len(pba) - 2]), arr[0: len(pba) - 2])
+            testing.assert_array_equal(np.asarray(pba[: len(pba) - 2]), arr[: len(pba) - 2])
+            testing.assert_array_equal(np.asarray(pba[0: len(pba) - 2]), arr[0: len(pba) - 2])
 
             # Start at 1, end at end:
-            testing.assert_array_equal(np.array(pba[1:]), arr[1:])
-            testing.assert_array_equal(np.array(pba[1: len(pba)]), arr[1: len(pba)])
+            testing.assert_array_equal(np.asarray(pba[1:]), arr[1:])
+            testing.assert_array_equal(np.asarray(pba[1: len(pba)]), arr[1: len(pba)])
 
             # Start at 1, end at less than the last:
-            testing.assert_array_equal(np.array(pba[1: len(pba) - 2]), arr[1: len(pba) - 2])
-            testing.assert_array_equal(np.array(pba[1: -2]), arr[1: -2])
+            testing.assert_array_equal(np.asarray(pba[1: len(pba) - 2]), arr[1: len(pba) - 2])
+            testing.assert_array_equal(np.asarray(pba[1: -2]), arr[1: -2])
 
             # Start at 8, end at end:
-            testing.assert_array_equal(np.array(pba[8:]), arr[8:])
-            testing.assert_array_equal(np.array(pba[8: len(pba)]), arr[8: len(pba)])
+            testing.assert_array_equal(np.asarray(pba[8:]), arr[8:])
+            testing.assert_array_equal(np.asarray(pba[8: len(pba)]), arr[8: len(pba)])
 
             # Start at 9, end at end:
-            testing.assert_array_equal(np.array(pba[9:]), arr[9:])
-            testing.assert_array_equal(np.array(pba[9: len(pba)]), arr[9: len(pba)])
+            testing.assert_array_equal(np.asarray(pba[9:]), arr[9:])
+            testing.assert_array_equal(np.asarray(pba[9: len(pba)]), arr[9: len(pba)])
 
             # And get an array of indices:
             inds = np.arange(len(pba))
@@ -719,37 +719,37 @@ class PackedBoolArrayTestCase(unittest.TestCase):
 
         for pba in long_arrays:
             # Test getting a single index.
-            arr = np.array(pba)
+            arr = np.asarray(pba)
             for i in range(len(pba)):
                 self.assertEqual(pba[i], arr[i])
 
             # Test getting slices.
             # The full slice.
-            testing.assert_array_equal(np.array(pba[:]), arr[:])
-            testing.assert_array_equal(np.array(pba[0: len(pba)]), arr[0: len(pba)])
+            testing.assert_array_equal(np.asarray(pba[:]), arr[:])
+            testing.assert_array_equal(np.asarray(pba[0: len(pba)]), arr[0: len(pba)])
 
             # Start at 0, end at less than the last:
-            testing.assert_array_equal(np.array(pba[: len(pba) - 2]), arr[: len(pba) - 2])
-            testing.assert_array_equal(np.array(pba[0: len(pba) - 2]), arr[0: len(pba) - 2])
+            testing.assert_array_equal(np.asarray(pba[: len(pba) - 2]), arr[: len(pba) - 2])
+            testing.assert_array_equal(np.asarray(pba[0: len(pba) - 2]), arr[0: len(pba) - 2])
 
             # Start at 1, end at end:
-            testing.assert_array_equal(np.array(pba[1:]), arr[1:])
-            testing.assert_array_equal(np.array(pba[1: len(pba)]), arr[1: len(pba)])
+            testing.assert_array_equal(np.asarray(pba[1:]), arr[1:])
+            testing.assert_array_equal(np.asarray(pba[1: len(pba)]), arr[1: len(pba)])
 
             # Start at 1, end at less than the last:
-            testing.assert_array_equal(np.array(pba[1: len(pba) - 2]), arr[1: len(pba) - 2])
-            testing.assert_array_equal(np.array(pba[1: -2]), arr[1: -2])
+            testing.assert_array_equal(np.asarray(pba[1: len(pba) - 2]), arr[1: len(pba) - 2])
+            testing.assert_array_equal(np.asarray(pba[1: -2]), arr[1: -2])
 
             # Start at 16, end at end:
-            testing.assert_array_equal(np.array(pba[16:]), arr[16:])
-            testing.assert_array_equal(np.array(pba[16: len(pba)]), arr[16: len(pba)])
+            testing.assert_array_equal(np.asarray(pba[16:]), arr[16:])
+            testing.assert_array_equal(np.asarray(pba[16: len(pba)]), arr[16: len(pba)])
 
             # Start at 16, end at 24 (aligned, less than end):
-            testing.assert_array_equal(np.array(pba[16: 24]), arr[16: 24])
+            testing.assert_array_equal(np.asarray(pba[16: 24]), arr[16: 24])
 
             # Start at 17, end at end:
-            testing.assert_array_equal(np.array(pba[17:]), arr[17:])
-            testing.assert_array_equal(np.array(pba[17: len(pba)]), arr[17: len(pba)])
+            testing.assert_array_equal(np.asarray(pba[17:]), arr[17:])
+            testing.assert_array_equal(np.asarray(pba[17: len(pba)]), arr[17: len(pba)])
 
             # And get an array of indices:
             inds = np.arange(len(pba))
@@ -770,7 +770,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
             for pba in pba_arrays:
                 # Test with constants.
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 pba_test2 = pba_test & True
                 pba_array2 = pba_array & True
@@ -786,18 +786,18 @@ class PackedBoolArrayTestCase(unittest.TestCase):
 
                 # Test with _PackedBoolArray.
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 other = pba_test.copy()
                 other[:] = True
                 other[1] = False
 
                 pba_test2 = pba_test & other
-                pba_array2 = pba_array & np.array(other)
+                pba_array2 = pba_array & np.asarray(other)
                 testing.assert_array_equal(pba_test2, pba_array2)
 
                 pba_test &= other
-                pba_array &= np.array(other)
+                pba_array &= np.asarray(other)
                 testing.assert_array_equal(pba_test, pba_array)
 
         pba = self._make_short_arrays()[0]
@@ -824,7 +824,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
             for pba in pba_arrays:
                 # Test with constants.
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 pba_test2 = pba_test[1: -2] & True
                 pba_array2 = pba_array[1: -2] & True
@@ -840,18 +840,18 @@ class PackedBoolArrayTestCase(unittest.TestCase):
 
                 # Test with _PackedBoolArray.
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 other = pba_test.copy()
                 other[:] = True
                 other[1] = False
 
                 pba_test2 = pba_test[1: -2] & other[1: -2]
-                pba_array2 = pba_array[1: -2] & np.array(other)[1: -2]
+                pba_array2 = pba_array[1: -2] & np.asarray(other)[1: -2]
                 testing.assert_array_equal(pba_test2, pba_array2)
 
                 pba_test[1: -2] &= other[1: -2]
-                pba_array[1: -2] &= np.array(other)[1: -2]
+                pba_array[1: -2] &= np.asarray(other)[1: -2]
                 testing.assert_array_equal(pba_test, pba_array)
 
     def test_or(self):
@@ -868,7 +868,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
             for pba in pba_arrays:
                 # Test with constants.
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 pba_test2 = pba_test | True
                 pba_array2 = pba_array | True
@@ -884,18 +884,18 @@ class PackedBoolArrayTestCase(unittest.TestCase):
 
                 # Test with _PackedBoolArray.
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 other = pba_test.copy()
                 other[:] = True
                 other[1] = False
 
                 pba_test2 = pba_test | other
-                pba_array2 = pba_array | np.array(other)
+                pba_array2 = pba_array | np.asarray(other)
                 testing.assert_array_equal(pba_test2, pba_array2)
 
                 pba_test |= other
-                pba_array |= np.array(other)
+                pba_array |= np.asarray(other)
                 testing.assert_array_equal(pba_test, pba_array)
 
         pba = self._make_short_arrays()[0]
@@ -922,7 +922,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
             for pba in pba_arrays:
                 # Test with constants.
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 pba_test2 = pba_test[1: -2] | True
                 pba_array2 = pba_array[1: -2] | True
@@ -938,22 +938,22 @@ class PackedBoolArrayTestCase(unittest.TestCase):
 
                 # Test with _PackedBoolArray.
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 other = pba_test.copy()
                 other[:] = True
                 other[1] = False
 
                 pba_test2 = pba_test[1: -2] | other[1: -2]
-                pba_array2 = pba_array[1: -2] | np.array(other)[1: -2]
+                pba_array2 = pba_array[1: -2] | np.asarray(other)[1: -2]
                 testing.assert_array_equal(pba_test2, pba_array2)
 
                 pba_test[1: -2] |= other[1: -2]
-                pba_array[1: -2] |= np.array(other)[1: -2]
+                pba_array[1: -2] |= np.asarray(other)[1: -2]
                 testing.assert_array_equal(pba_test, pba_array)
 
                 # Should do nothing.
-                pba_test[np.array([], dtype=np.int64)] |= True
+                pba_test[np.asarray([], dtype=np.int64)] |= True
                 testing.assert_array_equal(pba_test, pba_array)
 
     def test_xor(self):
@@ -970,7 +970,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
             for pba in pba_arrays:
                 # Test with constants.
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 pba_test2 = pba_test ^ True
                 pba_array2 = pba_array ^ True
@@ -986,18 +986,18 @@ class PackedBoolArrayTestCase(unittest.TestCase):
 
                 # Test with _PackedBoolArray.
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 other = pba_test.copy()
                 other[:] = True
                 other[1] = False
 
                 pba_test2 = pba_test ^ other
-                pba_array2 = pba_array ^ np.array(other)
+                pba_array2 = pba_array ^ np.asarray(other)
                 testing.assert_array_equal(pba_test2, pba_array2)
 
                 pba_test ^= other
-                pba_array ^= np.array(other)
+                pba_array ^= np.asarray(other)
                 testing.assert_array_equal(pba_test, pba_array)
 
         pba = self._make_short_arrays()[0]
@@ -1024,7 +1024,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
             for pba in pba_arrays:
                 # Test with constants.
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 pba_test2 = pba_test[1: -2] ^ True
                 pba_array2 = pba_array[1: -2] ^ True
@@ -1040,18 +1040,18 @@ class PackedBoolArrayTestCase(unittest.TestCase):
 
                 # Test with _PackedBoolArray.
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 other = pba_test.copy()
                 other[:] = True
                 other[1] = False
 
                 pba_test2 = pba_test[1: -2] ^ other[1: -2]
-                pba_array2 = pba_array[1: -2] ^ np.array(other)[1: -2]
+                pba_array2 = pba_array[1: -2] ^ np.asarray(other)[1: -2]
                 testing.assert_array_equal(pba_test2, pba_array2)
 
                 pba_test[1: -2] ^= other[1: -2]
-                pba_array[1: -2] ^= np.array(other)[1: -2]
+                pba_array[1: -2] ^= np.asarray(other)[1: -2]
                 testing.assert_array_equal(pba_test, pba_array)
 
     def test_invert(self):
@@ -1068,7 +1068,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
             for pba in pba_arrays:
                 # Test with constants.
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 pba_test2 = ~pba_test
                 pba_array2 = ~pba_array
@@ -1092,7 +1092,7 @@ class PackedBoolArrayTestCase(unittest.TestCase):
             for pba in pba_arrays:
                 # Test with constants.
                 pba_test = pba.copy()
-                pba_array = np.array(pba)
+                pba_array = np.asarray(pba)
 
                 pba_test[1: -2] = ~pba_test[1: -2]
                 pba_array[1: -2] = ~pba_array[1: -2]

--- a/tests/test_single_covpix.py
+++ b/tests/test_single_covpix.py
@@ -16,7 +16,7 @@ class SingleCovpixTestCase(unittest.TestCase):
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage,
                                                          nside_sparse,
                                                          np.float32)
-        pixels = np.array([1000, 100000, 10000000])
+        pixels = np.asarray([1000, 100000, 10000000])
         sparse_map[pixels] = 1.0
 
         cov_pixels, = np.where(sparse_map.coverage_mask)
@@ -48,7 +48,7 @@ class SingleCovpixTestCase(unittest.TestCase):
                                                          nside_sparse,
                                                          dtype,
                                                          primary='a')
-        pixels = np.array([1000, 100000, 10000000])
+        pixels = np.asarray([1000, 100000, 10000000])
         value = np.ones(1, dtype=dtype)
         sparse_map[pixels] = value
 
@@ -81,7 +81,7 @@ class SingleCovpixTestCase(unittest.TestCase):
                                                          WIDE_MASK,
                                                          wide_mask_maxbits=15)
 
-        pixels = np.array([1000, 100000, 10000000])
+        pixels = np.asarray([1000, 100000, 10000000])
         sparse_map.set_bits_pix(pixels, [4])
         sparse_map.set_bits_pix(pixels, [13])
 
@@ -112,7 +112,7 @@ class SingleCovpixTestCase(unittest.TestCase):
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage,
                                                          nside_sparse,
                                                          np.float32)
-        pixels = np.array([1000, 100000, 10000000])
+        pixels = np.asarray([1000, 100000, 10000000])
         sparse_map[pixels] = 1.0
 
         sub_map = sparse_map.get_single_covpix_map(40)
@@ -134,7 +134,7 @@ class SingleCovpixTestCase(unittest.TestCase):
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage,
                                                          nside_sparse,
                                                          np.float32)
-        pixels = np.array([1000, 100000, 10000000])
+        pixels = np.asarray([1000, 100000, 10000000])
         sparse_map[pixels] = 1.0
 
         cov_pixels, = np.where(sparse_map.coverage_mask)

--- a/tests/test_update_values.py
+++ b/tests/test_update_values.py
@@ -79,7 +79,7 @@ class UpdateValuesTestCase(unittest.TestCase):
 
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, dtype)
 
-        pixels = np.array([0, 1, 5, 10, 0])
+        pixels = np.asarray([0, 1, 5, 10, 0])
 
         self.assertRaises(ValueError, sparse_map.update_values_pix, pixels, 0.0)
         self.assertRaises(ValueError, sparse_map.__setitem__, pixels, 0.0)
@@ -96,35 +96,35 @@ class UpdateValuesTestCase(unittest.TestCase):
 
         # Check with new unique pixels
         pixels = np.arange(4)
-        values = np.array([2**0, 2**1, 2**2, 2**4], dtype=dtype)
+        values = np.asarray([2**0, 2**1, 2**2, 2**4], dtype=dtype)
         sparse_map.update_values_pix(pixels, values, operation='or')
 
         testing.assert_array_equal(sparse_map[pixels], values)
 
         # Check with pre-existing unique pixels
-        values2 = np.array([2**1, 2**2, 2**3, 2**4], dtype=dtype)
+        values2 = np.asarray([2**1, 2**2, 2**3, 2**4], dtype=dtype)
         sparse_map.update_values_pix(pixels, values2, operation='or')
 
         testing.assert_array_equal(sparse_map[pixels],
                                    values | values2)
 
         # Check with new non-unique pixels
-        pixels = np.array([100, 101, 102, 100])
-        values = np.array([2**0, 2**1, 2**2, 2**4], dtype=dtype)
+        pixels = np.asarray([100, 101, 102, 100])
+        values = np.asarray([2**0, 2**1, 2**2, 2**4], dtype=dtype)
         sparse_map.update_values_pix(pixels, values, operation='or')
 
         testing.assert_array_equal(sparse_map[pixels],
-                                   np.array([2**0 | 2**4, 2**1, 2**2, 2**0 | 2**4]))
+                                   np.asarray([2**0 | 2**4, 2**1, 2**2, 2**0 | 2**4]))
 
         # Check with pre-existing non-unique pixels
-        values = np.array([2**1, 2**2, 2**3, 2**5], dtype=dtype)
+        values = np.asarray([2**1, 2**2, 2**3, 2**5], dtype=dtype)
         sparse_map.update_values_pix(pixels, values, operation='or')
 
         testing.assert_array_equal(sparse_map[pixels],
-                                   np.array([2**0 | 2**4 | 2**1 | 2**5,
-                                             2**1 | 2**2,
-                                             2**2 | 2**3,
-                                             2**0 | 2**4 | 2**1 | 2**5]))
+                                   np.asarray([2**0 | 2**4 | 2**1 | 2**5,
+                                               2**1 | 2**2,
+                                               2**2 | 2**3,
+                                               2**0 | 2**4 | 2**1 | 2**5]))
 
     def test_update_values_and(self):
         """
@@ -138,7 +138,7 @@ class UpdateValuesTestCase(unittest.TestCase):
 
         # Check with new unique pixels
         pixels = np.arange(4)
-        values = np.array([2**0, 2**1, 2**2, 2**4], dtype=dtype)
+        values = np.asarray([2**0, 2**1, 2**2, 2**4], dtype=dtype)
 
         sparse_map.update_values_pix(pixels, values, operation='and')
         testing.assert_array_equal(sparse_map[pixels], values*0)
@@ -149,8 +149,8 @@ class UpdateValuesTestCase(unittest.TestCase):
         testing.assert_array_equal(sparse_map[pixels], values)
 
         # Check with new non-unique pixels
-        pixels = np.array([100, 101, 102, 100])
-        values = np.array([2**0, 2**1, 2**2, 2**4], dtype=dtype)
+        pixels = np.asarray([100, 101, 102, 100])
+        values = np.asarray([2**0, 2**1, 2**2, 2**4], dtype=dtype)
 
         sparse_map.update_values_pix(pixels, values, operation='and')
         testing.assert_array_equal(sparse_map[pixels], values*0)
@@ -183,7 +183,7 @@ class UpdateValuesTestCase(unittest.TestCase):
                 )
 
                 # Add a constant value
-                test_pix = np.array([0, 0, 10, 10, 1000, 1000, 1000, 10000])
+                test_pix = np.asarray([0, 0, 10, 10, 1000, 1000, 1000, 10000])
                 if update_type == 'single':
                     sparse_map.update_values_pix(test_pix, 1.0, operation='add')
                 else:
@@ -193,7 +193,7 @@ class UpdateValuesTestCase(unittest.TestCase):
                 testing.assert_array_equal(sparse_map[sparse_map.valid_pixels], [2.0, 2.0, 3.0, 1.0])
 
                 # Try again with a constant value, with a few old and a few new pixels
-                test_pix2 = np.array([0, 0, 1, 1, 1])
+                test_pix2 = np.asarray([0, 0, 1, 1, 1])
                 if update_type == 'single':
                     sparse_map.update_values_pix(test_pix2, 2.0, operation='add')
                 else:
@@ -206,8 +206,8 @@ class UpdateValuesTestCase(unittest.TestCase):
                 testing.assert_array_equal(sparse_map[sparse_map.valid_pixels], [6.0, 6.0, 2.0, 3.0, 1.0])
 
                 # And add some more with positions
-                ra = np.array([10.0, 10.0])
-                dec = np.array([70.0, 70.0])
+                ra = np.asarray([10.0, 10.0])
+                dec = np.asarray([70.0, 70.0])
                 test_pix3 = hpg.angle_to_pixel(sparse_map.nside_sparse, ra, dec)
 
                 sparse_map.update_values_pos(ra, dec, 3.0, operation='add')
@@ -243,7 +243,7 @@ class UpdateValuesTestCase(unittest.TestCase):
 
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, dtype)
 
-        pixels = np.array([0, 1, 5, 10, 20])
+        pixels = np.asarray([0, 1, 5, 10, 20])
         sparse_map = healsparse.HealSparseMap.make_empty(nside_coverage, nside_map, dtype)
         ra, dec = hpg.pixel_to_angle(nside_map, pixels)
 
@@ -251,7 +251,7 @@ class UpdateValuesTestCase(unittest.TestCase):
         testing.assert_array_almost_equal(sparse_map[pixels], 0.0)
 
         # Test non-unique raise
-        pixels = np.array([0, 1, 5, 10, 0])
+        pixels = np.asarray([0, 1, 5, 10, 0])
         ra, dec = hpg.pixel_to_angle(nside_map, pixels)
         self.assertRaises(ValueError, sparse_map.update_values_pos, ra, dec, 0.0)
 

--- a/tests/test_widemasks.py
+++ b/tests/test_widemasks.py
@@ -521,8 +521,8 @@ class WideMasksTestCase(unittest.TestCase):
         self.assertTrue(smap.is_wide_mask_map)
         self.assertEqual(smap.wide_mask_maxbits, 16)
 
-        ra = np.array([200.1, 200.15])
-        dec = np.array([0.05, 0.015])
+        ra = np.asarray([200.1, 200.15])
+        dec = np.asarray([0.05, 0.015])
 
         vals = smap.get_values_pos(ra, dec, lonlat=True)
         testing.assert_array_equal(vals[:, 0], [2**4, 0])
@@ -632,11 +632,11 @@ class WideMasksTestCase(unittest.TestCase):
         # And mask specific bits that are not set
         masked_map = int_map.apply_mask(mask_map, mask_bit_arr=[16], in_place=False)
         values = mask_map.get_values_pix(mask_map.valid_pixels)
-        masked_pixels, = np.where((values[:, 0] & (2**16)) > 0)
+        masked_pixels, = np.where((values[:, 0] & (2**4)) > 0)
         testing.assert_equal(masked_pixels.size, 0)
 
         still_good, = np.where((int_map.get_values_pix(valid_pixels) > 0) &
-                               ((mask_map.get_values_pix(valid_pixels)[:, 0] & 2**16) == 0))
+                               ((mask_map.get_values_pix(valid_pixels)[:, 0] & 2**4) == 0))
         testing.assert_array_equal(masked_map.get_values_pix(valid_pixels[still_good]), 1)
 
     def test_wide_mask_applied_mask(self):


### PR DESCRIPTION
This PR also updates numpy 2 deprecations and fixes test comparisons that were inconsistent for float32 types for numpy1 vs numpy2.