### PR TITLE
Add support for hdf5 files

### DIFF
--- a/.github/workflows/python-package-pr.yml
+++ b/.github/workflows/python-package-pr.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[parquet,test,test_with_healpy]
+        pip install .[parquet,test,test_with_healpy,hdf5]
     - name: Lint with flake8
       run: |
         flake8

--- a/docs/basic_interface.rst
+++ b/docs/basic_interface.rst
@@ -208,12 +208,17 @@ Writing a :code:`HealSparseMap` is easy.  To write a map in the default FITS for
 
     map3.write('output_file.hs', clobber=False)
 
-And to write a map in the Parquet format with ``pyarrow``:
+to write a map in the Parquet format with ``pyarrow``:
 
 .. code-block :: python
 
     map3.write('output_file.hsparquet', clobber=False, format='parquet')
 
+and to write a map in the HDF5 format with ``h5py``:
+
+.. code-block :: python
+
+    map3.write('output_file.h5', clobber=False, format='hdf5')
 
 Metadata
 --------

--- a/docs/filespec.rst
+++ b/docs/filespec.rst
@@ -285,7 +285,7 @@ HealSparseMap HDF5 Serialization
 A :code:`HealSparseMap` may also be serialized to an HDF5 file. 
 Multiple :code:`HealSparseMap` objects can be stored in the same HDF5 file.
 Each :code:`HealSparseMap` is stored in a different HDF5 group.
-They are not required to have the same mask, :code:`nside_coverage` or :code:`nside_sparse`.
+They are not required to have the same mask, :code:`nside_coverage`, or :code:`nside_sparse`.
 
 All datasets are written with gzip compression and chunked such that each chunk corresponds to a single coverage pixel.
 

--- a/docs/filespec.rst
+++ b/docs/filespec.rst
@@ -276,3 +276,123 @@ The other columns in the overflow coverage pixel are filled with the default sen
 
 If the sparse map is a bit-packed mask, the schema is the same as for a regular sparse map image.
 In this case, as with the FITS serialization, the sparse map is stored as an array of unsigned 8-bit integers which is the in-memory backing of the bit-packed array.
+
+.. _hdf5_format:
+
+HealSparseMap HDF5 Serialization
+================================
+
+A :code:`HealSparseMap` may also be serialized to an HDF5 file. 
+Multiple :code:`HealSparseMap` objects can be stored in the same HDF5 file.
+Each :code:`HealSparseMap` is stored in a different HDF5 group.
+They are not required to have the same mask, :code:`nside_coverage` or :code:`nside_sparse`.
+
+All datasets are written with gzip compression and chunked such that each chunk corresponds to a single coverage pixel.
+
+HDF5 Group Layout
+-----------------
+
+A serialized :code:`HealSparseMap` is stored within a single HDF5 group (default name :code:`"map"`), which contains:
+
+* A dataset encoding the coverage map
+* One or more datasets encoding the sparse map
+* Attributes storing map metadata
+
+Coverage Map
+------------
+
+The coverage map is stored as a one-dimensional dataset:
+
+* **Dataset name:** :code:`cov_index_map`
+* **Datatype:** :code:`numpy.int64`
+* **Shape:** :code:`(12 * nside_coverage * nside_coverage,)`
+
+This dataset is a direct serialization of the in-memory coverage index map,
+following the same conventions described in :ref:`coverage_map`.
+
+Sparse Map
+----------
+
+The sparse map is stored as a two-dimensional dataset, where each row corresponds to a single coverage pixel.
+The first row always represents the overflow (sentinel) coverage pixel.
+
+Regular Sparse Map
+^^^^^^^^^^^^^^^^^^
+
+For regular (non-record, non-wide-mask, non-bit-packed) sparse maps:
+
+* **Dataset name:** :code:`sparse_map`
+* **Shape:** :code:`(ncov_in_sparse, nfine_per_cov)`
+* **Datatype:** Sparse map datatype
+
+where:
+
+* :code:`ncov_in_sparse`: The number of coverage pixels containing non-sentinel data, plus one for the overflow pixel
+ 
+Each row contains the :code:`nfine_per_cov` sparse pixel values associated with a single coverage pixel.
+The dataset is chunked as :code:`(1, nfine_per_cov)` to allow efficient access to individual coverage pixels.
+
+Sparse Map Record Array
+^^^^^^^^^^^^^^^^^^^^^^^
+
+If the sparse map is a numpy record array, each field is stored in a separate subgroup:
+
+* **Group name:** Name of the record field
+* **Dataset name:** :code:`sparse_map`
+* **Shape:** :code:`(ncov_in_sparse, nfine_per_cov)`
+* **Datatype:** Field datatype
+
+All fields share the same coverage map indexing.
+
+Sparse Map Wide Mask
+^^^^^^^^^^^^^^^^^^^^
+
+For wide mask maps, the sparse map is stored as a three-dimensional dataset:
+
+* **Dataset name:** :code:`sparse_map`
+* **Shape:** :code:`(ncov_in_sparse, nfine_per_cov, wide_mask_width)`
+* **Datatype:** :code:`numpy.uint8`
+
+Each sparse pixel is represented by :code:`wide_mask_width` bytes.
+The dataset is chunked as :code:`(1, nfine_per_cov, wide_mask_width)`.
+
+Sparse Map Bit-Packed Mask
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For bit-packed mask maps, the sparse map is stored in its packed representation:
+
+* **Dataset name:** :code:`sparse_map`
+* **Shape:** :code:`(ncov_in_sparse, nfine_per_cov // 8)`
+* **Datatype:** :code:`numpy.uint8`
+
+Each byte encodes eight sparse pixels.
+
+Metadata and Attributes
+-----------------------
+
+All remaining map metadata is stored as HDF5 group attributes.
+The following attributes are required:
+
+* :code:`nside_sparse`
+* :code:`nside_coverage`
+* :code:`sentinel`
+* :code:`primary`
+* :code:`nest` (always :code:`True`)
+
+The following flags describe the sparse map type:
+
+* :code:`is_rec_array`
+* :code:`is_bit_packed`
+* :code:`is_wide_mask`
+* :code:`wide_mask_width`
+
+Any additional metadata attached to the :code:`HealSparseMap` object is also written as group attributes.
+
+Partial Reads
+-------------
+
+The HDF5 format supports reading a subset of coverage pixels.
+When a subset is requested, only the corresponding rows of the sparse map datasets are read.
+The overflow (sentinel) coverage pixel is always included as the first row.
+
+On read, the sparse map rows are reshaped and reordered to reconstruct the in-memory sparse map layout described in :ref:`sparse_map`.

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -386,7 +386,7 @@ class HealSparseMap(object):
             the ``healpix`` EXPLICIT format does not maintain all metadata and
             coverage information.
         hdf5_group: `str`, optional
-            If file format is ``hdf5``, save to this group, otheriwse unused.
+            If file format is ``hdf5``, save to this group, otherwise unused.
 
         Raises
         ------

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -119,7 +119,7 @@ class HealSparseMap(object):
     @classmethod
     def read(cls, filename, nside_coverage=None, pixels=None, header=False,
              degrade_nside=None, weightfile=None, reduction='mean',
-             use_threads=False, group='map'):
+             use_threads=False, hdf5_group='map'):
         """
         Read in a HealSparseMap.
 
@@ -149,9 +149,8 @@ class HealSparseMap(object):
            Not yet implemented for parquet files.
         use_threads : `bool`, optional
            Use multithreaded reading for parquet files.
-        group : `str`, optional
-            if file is hdf5, read from this group
-            default is `map`
+        hdf5_group : `str`, optional
+           If file format is ``hdf5``, read from this group, otheriwse unused.
 
         Returns
         -------
@@ -163,7 +162,7 @@ class HealSparseMap(object):
         return _read_map(cls, filename, nside_coverage=nside_coverage, pixels=pixels,
                          header=header, degrade_nside=degrade_nside,
                          weightfile=weightfile, reduction=reduction, use_threads=use_threads,
-                         hdf5_group=group)
+                         hdf5_group=hdf5_group)
 
     @classmethod
     def make_empty(cls, nside_coverage, nside_sparse, dtype, primary=None, sentinel=None,
@@ -363,7 +362,7 @@ class HealSparseMap(object):
 
         return cov_map, sparse_map
 
-    def write(self, filename, clobber=False, nocompress=False, format='fits', nside_io=4, group='map'):
+    def write(self, filename, clobber=False, nocompress=False, format='fits', nside_io=4, hdf5_group='map'):
         """
         Write a HealSparseMap to a file.  Use the `metadata` property from
         the map to persist additional information in the fits header.
@@ -386,10 +385,8 @@ class HealSparseMap(object):
             File format.  May be ``fits``, ``parquet``, ``hdf5`` or ``healpix``. Note that
             the ``healpix`` EXPLICIT format does not maintain all metadata and
             coverage information.
-        group: `str`, optional
-            If file format is ``hdf5``, save to this group
-            otheriwse unused
-            default is ``map``
+        hdf5_group: `str`, optional
+            If file format is ``hdf5``, save to this group, otheriwse unused.
 
         Raises
         ------
@@ -397,7 +394,7 @@ class HealSparseMap(object):
         ValueError if nside_io is out of range.
         """
         _write_map(self, filename, clobber=clobber, nocompress=nocompress, format=format,
-                   nside_io=nside_io, hdf5_group=group)
+                   nside_io=nside_io, hdf5_group=hdf5_group)
 
     def write_moc(self, filename, clobber=False):
         """

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -162,7 +162,8 @@ class HealSparseMap(object):
         """
         return _read_map(cls, filename, nside_coverage=nside_coverage, pixels=pixels,
                          header=header, degrade_nside=degrade_nside,
-                         weightfile=weightfile, reduction=reduction, use_threads=use_threads, hdf5_group=group)
+                         weightfile=weightfile, reduction=reduction, use_threads=use_threads,
+                         hdf5_group=group)
 
     @classmethod
     def make_empty(cls, nside_coverage, nside_sparse, dtype, primary=None, sentinel=None,

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -119,7 +119,7 @@ class HealSparseMap(object):
     @classmethod
     def read(cls, filename, nside_coverage=None, pixels=None, header=False,
              degrade_nside=None, weightfile=None, reduction='mean',
-             use_threads=False):
+             use_threads=False, group='map'):
         """
         Read in a HealSparseMap.
 
@@ -149,6 +149,9 @@ class HealSparseMap(object):
            Not yet implemented for parquet files.
         use_threads : `bool`, optional
            Use multithreaded reading for parquet files.
+        group : `str`, optional
+            if file is hdf5, read from this group
+            default is `map`
 
         Returns
         -------
@@ -159,7 +162,7 @@ class HealSparseMap(object):
         """
         return _read_map(cls, filename, nside_coverage=nside_coverage, pixels=pixels,
                          header=header, degrade_nside=degrade_nside,
-                         weightfile=weightfile, reduction=reduction, use_threads=use_threads)
+                         weightfile=weightfile, reduction=reduction, use_threads=use_threads, hdf5_group=group)
 
     @classmethod
     def make_empty(cls, nside_coverage, nside_sparse, dtype, primary=None, sentinel=None,
@@ -359,7 +362,7 @@ class HealSparseMap(object):
 
         return cov_map, sparse_map
 
-    def write(self, filename, clobber=False, nocompress=False, format='fits', nside_io=4):
+    def write(self, filename, clobber=False, nocompress=False, format='fits', nside_io=4, group='map'):
         """
         Write a HealSparseMap to a file.  Use the `metadata` property from
         the map to persist additional information in the fits header.
@@ -379,9 +382,13 @@ class HealSparseMap(object):
             Must be less than or equal to nside_coverage, and not greater than 16.
             This option only applies if format=``parquet``.
         format : `str`, optional
-            File format.  May be ``fits``, ``parquet``, or ``healpix``. Note that
+            File format.  May be ``fits``, ``parquet``, ``hdf5`` or ``healpix``. Note that
             the ``healpix`` EXPLICIT format does not maintain all metadata and
             coverage information.
+        group: `str`, optional
+            If file format is ``hdf5``, save to this group
+            otheriwse unused
+            default is ``map``
 
         Raises
         ------
@@ -389,7 +396,7 @@ class HealSparseMap(object):
         ValueError if nside_io is out of range.
         """
         _write_map(self, filename, clobber=clobber, nocompress=nocompress, format=format,
-                   nside_io=nside_io)
+                   nside_io=nside_io, hdf5_group=group)
 
     def write_moc(self, filename, clobber=False):
         """

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -150,7 +150,7 @@ class HealSparseMap(object):
         use_threads : `bool`, optional
            Use multithreaded reading for parquet files.
         hdf5_group : `str`, optional
-           If file format is ``hdf5``, read from this group, otheriwse unused.
+           If file format is ``hdf5``, read from this group, otherwise unused.
 
         Returns
         -------

--- a/healsparse/io_map.py
+++ b/healsparse/io_map.py
@@ -75,7 +75,6 @@ def _read_map(healsparse_class, filename, nside_coverage=None, pixels=None, head
                                  weightfile=weightfile, reduction=reduction,
                                  use_threads=use_threads)
     elif is_hdf5_file:
-        # TODO: pass pixels, degrade options, etc to hdf5 read
         return _read_map_hdf5(healsparse_class, filename, group=hdf5_group,
                               pixels=pixels, header=header, degrade_nside=degrade_nside,
                               weightfile=weightfile, reduction=reduction,)

--- a/healsparse/io_map.py
+++ b/healsparse/io_map.py
@@ -5,10 +5,11 @@ from .io_map_fits import _read_map_fits, _write_map_fits, _write_moc_fits
 from .parquet_shim import check_parquet_dataset
 from .io_map_parquet import _read_map_parquet, _write_map_parquet
 from .io_map_healpix import _write_map_healpix
+from .io_map_hdf5 import _read_map_hdf5, _write_map_hdf5, check_hdf5_file
 
 
 def _read_map(healsparse_class, filename, nside_coverage=None, pixels=None, header=False,
-              degrade_nside=None, weightfile=None, reduction='mean', use_threads=False):
+              degrade_nside=None, weightfile=None, reduction='mean', use_threads=False, hdf5_group='map'):
     """
     Internal function to check the map filetype and read in a HealSparseMap.
 
@@ -37,6 +38,8 @@ def _read_map(healsparse_class, filename, nside_coverage=None, pixels=None, head
         (mean, median, std, max, min, and, or, sum, prod, wmean).
     use_threads : `bool`, optional
         Use multithreaded reading for parquet files.
+    hdf5_group: `str`, optional
+        hdf5 group to read from (only used if reading from an hdf5 file)
 
     Returns
     -------
@@ -47,6 +50,7 @@ def _read_map(healsparse_class, filename, nside_coverage=None, pixels=None, head
     """
     is_fits_file = False
     is_parquet_file = False
+    is_hdf5_file = False
 
     try:
         fits = HealSparseFits(filename)
@@ -58,6 +62,9 @@ def _read_map(healsparse_class, filename, nside_coverage=None, pixels=None, head
     if not is_fits_file:
         is_parquet_file = check_parquet_dataset(filename)
 
+    if not is_fits_file and not is_parquet_file:
+        is_hdf5_file = check_hdf5_file(filename)
+
     if is_fits_file:
         return _read_map_fits(healsparse_class, filename, nside_coverage=nside_coverage,
                               pixels=pixels, header=header, degrade_nside=degrade_nside,
@@ -67,13 +74,15 @@ def _read_map(healsparse_class, filename, nside_coverage=None, pixels=None, head
                                  pixels=pixels, header=header, degrade_nside=degrade_nside,
                                  weightfile=weightfile, reduction=reduction,
                                  use_threads=use_threads)
+    elif is_hdf5_file:
+        return _read_map_hdf5(healsparse_class, filename, hdf5_group='map')
     elif not os.path.isfile(filename):
         raise IOError("Filename %s could not be found." % (filename))
     else:
-        raise NotImplementedError("HealSparse only supports fits and parquet files (with pyarrow).")
+        raise NotImplementedError("HealSparse only supports fits, hdf5 and parquet files (with pyarrow).")
 
 
-def _write_map(hsp_map, filename, clobber=False, nocompress=False, format='fits', nside_io=4):
+def _write_map(hsp_map, filename, clobber=False, nocompress=False, format='fits', nside_io=4, hdf5_group='map'):
     """
     Internal method to write a HealSparseMap to a file, and check formats.
     Use the `metadata` property from
@@ -96,7 +105,7 @@ def _write_map(hsp_map, filename, clobber=False, nocompress=False, format='fits'
         This option only applies if format=``parquet``.
         Must be less than or equal to nside_coverage, and not greater than 16.
     format : `str`, optional
-        File format.  May be ``fits``, ``parquet``, or ``healpix``.
+        File format.  May be ``fits``, ``parquet``, ``hdf5`` or ``healpix``.
 
     Raises
     ------
@@ -109,8 +118,10 @@ def _write_map(hsp_map, filename, clobber=False, nocompress=False, format='fits'
         _write_map_parquet(hsp_map, filename, clobber=clobber, nside_io=nside_io)
     elif format == 'healpix':
         _write_map_healpix(hsp_map, filename, clobber=clobber)
+    elif format == 'hdf5':
+        _write_map_hdf5(hsp_map, filename, clobber=clobber)
     else:
-        raise NotImplementedError("Only 'fits', 'parquet' and 'healpix' file formats are supported.")
+        raise NotImplementedError("Only 'fits', 'parquet', 'hdf5' and 'healpix' file formats are supported.")
 
 
 def _write_moc(hsp_map, filename, clobber=False):

--- a/healsparse/io_map.py
+++ b/healsparse/io_map.py
@@ -75,7 +75,7 @@ def _read_map(healsparse_class, filename, nside_coverage=None, pixels=None, head
                                  weightfile=weightfile, reduction=reduction,
                                  use_threads=use_threads)
     elif is_hdf5_file:
-        return _read_map_hdf5(healsparse_class, filename, group=hdf5_group,
+        return _read_map_hdf5(healsparse_class, filename, hdf5_group=hdf5_group,
                               pixels=pixels, header=header, degrade_nside=degrade_nside,
                               weightfile=weightfile, reduction=reduction)
     elif not os.path.isfile(filename):
@@ -122,7 +122,7 @@ def _write_map(hsp_map, filename, clobber=False, nocompress=False, format='fits'
     elif format == 'healpix':
         _write_map_healpix(hsp_map, filename, clobber=clobber)
     elif format == 'hdf5':
-        _write_map_hdf5(hsp_map, filename, clobber=clobber, group=hdf5_group)
+        _write_map_hdf5(hsp_map, filename, clobber=clobber, hdf5_group=hdf5_group)
     else:
         raise NotImplementedError("Only 'fits', 'parquet', 'hdf5' and 'healpix' file formats are supported.")
 

--- a/healsparse/io_map.py
+++ b/healsparse/io_map.py
@@ -58,6 +58,7 @@ def _read_map(healsparse_class, filename, nside_coverage=None, pixels=None, head
         fits.close()
     except (OSError, UnicodeDecodeError):
         pass
+    # UnicodeDecodeError occurs when trying to read an hdf5 file as if it's FITS
 
     if not is_fits_file:
         is_parquet_file = check_parquet_dataset(filename)

--- a/healsparse/io_map.py
+++ b/healsparse/io_map.py
@@ -39,7 +39,7 @@ def _read_map(healsparse_class, filename, nside_coverage=None, pixels=None, head
     use_threads : `bool`, optional
         Use multithreaded reading for parquet files.
     hdf5_group: `str`, optional
-        hdf5 group to read from (only used if reading from an hdf5 file)
+        Read from this hdf5 group (only used reading from an hdf5 file).
 
     Returns
     -------
@@ -77,11 +77,11 @@ def _read_map(healsparse_class, filename, nside_coverage=None, pixels=None, head
     elif is_hdf5_file:
         return _read_map_hdf5(healsparse_class, filename, group=hdf5_group,
                               pixels=pixels, header=header, degrade_nside=degrade_nside,
-                              weightfile=weightfile, reduction=reduction,)
+                              weightfile=weightfile, reduction=reduction)
     elif not os.path.isfile(filename):
         raise IOError("Filename %s could not be found." % (filename))
     else:
-        raise NotImplementedError("HealSparse only supports fits, hdf5 and parquet files (with pyarrow).")
+        raise NotImplementedError("HealSparse only supports fits, hdf5 (with h5py), and parquet files (with pyarrow).")
 
 
 def _write_map(hsp_map, filename, clobber=False, nocompress=False, format='fits', nside_io=4,

--- a/healsparse/io_map.py
+++ b/healsparse/io_map.py
@@ -75,7 +75,10 @@ def _read_map(healsparse_class, filename, nside_coverage=None, pixels=None, head
                                  weightfile=weightfile, reduction=reduction,
                                  use_threads=use_threads)
     elif is_hdf5_file:
-        return _read_map_hdf5(healsparse_class, filename, hdf5_group='map')
+        # TODO: pass pixels, degrade options, etc to hdf5 read
+        return _read_map_hdf5(healsparse_class, filename, hdf5_group=hdf5_group,
+                              pixels=pixels, header=header, degrade_nside=degrade_nside,
+                              weightfile=weightfile, reduction=reduction,)
     elif not os.path.isfile(filename):
         raise IOError("Filename %s could not be found." % (filename))
     else:
@@ -119,7 +122,7 @@ def _write_map(hsp_map, filename, clobber=False, nocompress=False, format='fits'
     elif format == 'healpix':
         _write_map_healpix(hsp_map, filename, clobber=clobber)
     elif format == 'hdf5':
-        _write_map_hdf5(hsp_map, filename, clobber=clobber)
+        _write_map_hdf5(hsp_map, filename, clobber=clobber, group=hdf5_group)
     else:
         raise NotImplementedError("Only 'fits', 'parquet', 'hdf5' and 'healpix' file formats are supported.")
 

--- a/healsparse/io_map.py
+++ b/healsparse/io_map.py
@@ -81,7 +81,8 @@ def _read_map(healsparse_class, filename, nside_coverage=None, pixels=None, head
     elif not os.path.isfile(filename):
         raise IOError("Filename %s could not be found." % (filename))
     else:
-        raise NotImplementedError("HealSparse only supports fits, hdf5 (with h5py), and parquet files (with pyarrow).")
+        raise NotImplementedError(
+            "HealSparse only supports fits, hdf5 (with h5py), and parquet files (with pyarrow).")
 
 
 def _write_map(hsp_map, filename, clobber=False, nocompress=False, format='fits', nside_io=4,

--- a/healsparse/io_map.py
+++ b/healsparse/io_map.py
@@ -56,7 +56,7 @@ def _read_map(healsparse_class, filename, nside_coverage=None, pixels=None, head
         fits = HealSparseFits(filename)
         is_fits_file = True
         fits.close()
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         pass
 
     if not is_fits_file:
@@ -76,7 +76,7 @@ def _read_map(healsparse_class, filename, nside_coverage=None, pixels=None, head
                                  use_threads=use_threads)
     elif is_hdf5_file:
         # TODO: pass pixels, degrade options, etc to hdf5 read
-        return _read_map_hdf5(healsparse_class, filename, hdf5_group=hdf5_group,
+        return _read_map_hdf5(healsparse_class, filename, group=hdf5_group,
                               pixels=pixels, header=header, degrade_nside=degrade_nside,
                               weightfile=weightfile, reduction=reduction,)
     elif not os.path.isfile(filename):

--- a/healsparse/io_map.py
+++ b/healsparse/io_map.py
@@ -84,7 +84,8 @@ def _read_map(healsparse_class, filename, nside_coverage=None, pixels=None, head
         raise NotImplementedError("HealSparse only supports fits, hdf5 and parquet files (with pyarrow).")
 
 
-def _write_map(hsp_map, filename, clobber=False, nocompress=False, format='fits', nside_io=4, hdf5_group='map'):
+def _write_map(hsp_map, filename, clobber=False, nocompress=False, format='fits', nside_io=4,
+               hdf5_group='map'):
     """
     Internal method to write a HealSparseMap to a file, and check formats.
     Use the `metadata` property from

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -226,7 +226,7 @@ def _read_map_hdf5(
         if is_rec_array:
             dtype = []
             for name in grp:
-                if name in ["coverage_pixel", "coverage_value"]:
+                if name in ["cov_index_map"]:
                     continue
                 dtype.append((name, grp[name]["sparse_map"].dtype))
 

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -1,8 +1,15 @@
-import h5py
 import os
 import numpy as np
 from .utils import WIDE_MASK
 from .packedBoolArray import _PackedBoolArray
+import warnings
+
+use_hdf5 = False
+try:
+    import h5py
+    use_hdf5 = True
+except ImportError:
+    pass
 
 def _write_map_hdf5(hsp_map, filepath, group='map', clobber=False):
     """
@@ -162,3 +169,28 @@ def _read_map_hdf5(healsparse_class, filename, group='map'):
                                      metadata=user_metadata)
 
         return hsp_map
+    
+def check_hdf5_file(filepath):
+    """
+    Check if a filepath points to an hdf5 file
+
+    Parameters
+    ----------
+    filepath : `str`
+        File path to check.
+
+    Returns
+    -------
+    is_hdf5_file : `bool`
+        True if it is an hdf5 file
+
+    Raises
+    ------
+    Warns if hdf5 is not installed.
+    """
+    if not use_hdf5:
+        warnings.warn("Cannot access hdf5 files without h5py",
+                      UserWarning)
+        return False
+
+    return h5py.is_hdf5(filepath)

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -34,9 +34,12 @@ def _write_map_hdf5(hsp_map, filepath, group="map", clobber=False):
         Overwrite the file/group if it exists.
     """
     if os.path.isfile(filepath) and not clobber:
-        raise RuntimeError("Filename %s exists and clobber is False." % (filepath))
+        with h5py.File(filepath, mode) as f:
+            group_exists = group in f.keys()
+        if group_exists:
+            raise RuntimeError(f"Filename {filepath} with group {group} exists and clobber is False.")
 
-    mode = "a"  # append mode so we can save to an existing file
+    mode = "a"  # append mode so we can save to an existing file if we want
     with h5py.File(filepath, mode) as f:
         if group in f:
             if clobber:

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -87,7 +87,8 @@ def _write_map_hdf5(hsp_map, filepath, group='map', clobber=False):
                 grp.attrs[k] = str(v)
 
 
-def _read_map_hdf5(healsparse_class, filename, group='map'):
+def _read_map_hdf5(healsparse_class, filename, group='map', pixels=None, header=False, 
+                   degrade_nside=None, weightfile=None, reduction='mean' ):
     """
     Internal method to read a HealSparseMap from an HDF5 file in a specified group.
 
@@ -99,7 +100,17 @@ def _read_map_hdf5(healsparse_class, filename, group='map'):
         HDF5 file path
     group : str
         HDF5 group containing the map
-
+    pixels : `list`, optional
+        List of coverage map pixels to read.
+    header : `bool`, optional
+        Return stored metadata/header as well as map?  Default is False.
+        Not implemented for hdf5
+    degrade_nside : `int`, optional
+        Degrade map to this nside on read.
+    weightfile : `str`, optional
+        Weight map for weighted degrade.
+    reduction : `str`, optional
+        Reduction method for degrade-on-read.
     Returns
     -------
     HealSparseMap instance
@@ -114,7 +125,10 @@ def _read_map_hdf5(healsparse_class, filename, group='map'):
         coverage_mask = np.zeros(coverage_pixels.max() + 1, dtype=bool)
         coverage_mask[coverage_pixels] = coverage_values
 
-        pixels = grp['pixel'][:]
+        if pixels is not None:
+            pixels = np.atleast_1d(pixels)
+        else:
+            pixels = grp['pixel'][:]
 
         is_rec_array = grp.attrs.get('is_rec_array', False)
         is_bit_packed = grp.attrs.get('is_bit_packed', False)
@@ -155,18 +169,25 @@ def _read_map_hdf5(healsparse_class, filename, group='map'):
             elif is_bit_packed:
                 sparse_map = _PackedBoolArray(data_buffer=sparse_map)
 
-        # User metadata
-        user_metadata = {k: grp.attrs[k] for k in grp.attrs
-                         if k not in ['nside_sparse', 'sentinel', 'primary',
-                                      'nest', 'is_rec_array', 'is_bit_packed',
-                                      'is_wide_mask', 'wide_mask_width']}
+        # metadata
+        metadata = {k: grp.attrs[k] for k in grp.attrs
+                        if k not in ['nside_sparse', 'sentinel', 'primary',
+                                    'nest', 'is_rec_array', 'is_bit_packed',
+                                    'is_wide_mask', 'wide_mask_width']}
 
         hsp_map = healsparse_class(cov_map=coverage_mask,
                                      sparse_map=sparse_map,
                                      nside_sparse=grp.attrs['nside_sparse'],
                                      primary=grp.attrs.get('primary', None),
                                      sentinel=sentinel,
-                                     metadata=user_metadata)
+                                     metadata=metadata)
+    
+        if degrade_nside is not None:
+            hsp_map = hsp_map.degrade(
+                degrade_nside,
+                reduction=reduction,
+                weightfile=weightfile
+            )
 
         return hsp_map
     

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -75,7 +75,7 @@ def _write_map_hdf5(hsp_map, filepath, group='map', clobber=False):
         # Metadata
         grp.attrs['nside_sparse'] = hsp_map.nside_sparse
         grp.attrs['nside_coverage'] = hsp_map.nside_coverage
-        grp.attrs['sentinel'] = float(hsp_map._sentinel) if np.isscalar(hsp_map._sentinel) else str(hsp_map._sentinel)
+        grp.attrs['sentinel'] = hsp_map._sentinel
         grp.attrs['primary'] = '' if hsp_map._primary is None else hsp_map._primary
         grp.attrs['nest'] = True  # always True
 
@@ -145,16 +145,6 @@ def _read_map_hdf5(healsparse_class, filename, group='map', pixels=None, header=
 
         # sentinel handling
         sentinel = grp.attrs['sentinel']
-        try:
-            sentinel = float(sentinel)
-        except ValueError:
-            if sentinel == 'UNSEEN':
-                import hpgeom as hpg
-                sentinel = hpg.UNSEEN
-            elif sentinel == 'False':
-                sentinel = False
-            elif sentinel == 'True':
-                sentinel = True
 
         #figure out where in the sparse map each valid pixel should go
         cov_pix = cov_map.cov_pixels(valid_pixels) #coverage pixel for each valid sparse pixel

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -87,7 +87,7 @@ def _write_map_hdf5(hsp_map, filepath, group='map', clobber=False):
 
         if hsp_map.metadata is not None:
             for k, v in hsp_map.metadata.items():
-                grp.attrs[k] = str(v)
+                grp.attrs[k] = v
 
 
 def _read_map_hdf5(healsparse_class, filename, group='map', pixels=None, header=False, 

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -80,7 +80,7 @@ def _write_map_hdf5(hsp_map, filepath, group='map', clobber=False):
                 grp.attrs[k] = str(v)
 
 
-def read_map_hdf5(healsparse_class, filename, group='map'):
+def _read_map_hdf5(healsparse_class, filename, group='map'):
     """
     Internal method to read a HealSparseMap from an HDF5 file in a specified group.
 

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -66,9 +66,8 @@ def _write_map_hdf5(hsp_map, filepath, hdf5_group="map", clobber=False):
                     compression="gzip",
                 )
         elif hsp_map.is_bit_packed_map:
-            # save as bool array rather than packed to keep the same pixel as other maps when reading
+            # for bit packed maps, save packed array
             sparse_map_reshape = hsp_map._sparse_map.data_array.reshape(ncov_in_sparse, nfine_per_cov//8)
-            # save the bit packed map as a 1D array
             grp.create_dataset(
                 "sparse_map",
                 data=sparse_map_reshape,

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -3,6 +3,8 @@ import numpy as np
 from .utils import WIDE_MASK
 from .packedBoolArray import _PackedBoolArray
 import warnings
+from .healSparseCoverage import HealSparseCoverage
+import healpy as hp
 
 use_hdf5 = False
 try:
@@ -71,7 +73,8 @@ def _write_map_hdf5(hsp_map, filepath, group='map', clobber=False):
             grp.create_dataset('value', data=sparse_values, compression='gzip')
 
         # Metadata
-        grp.attrs['nside_sparse'] = hsp_map._nside_sparse
+        grp.attrs['nside_sparse'] = hsp_map.nside_sparse
+        grp.attrs['nside_coverage'] = hsp_map.nside_coverage
         grp.attrs['sentinel'] = float(hsp_map._sentinel) if np.isscalar(hsp_map._sentinel) else str(hsp_map._sentinel)
         grp.attrs['primary'] = '' if hsp_map._primary is None else hsp_map._primary
         grp.attrs['nest'] = True  # always True
@@ -102,6 +105,7 @@ def _read_map_hdf5(healsparse_class, filename, group='map', pixels=None, header=
         HDF5 group containing the map
     pixels : `list`, optional
         List of coverage map pixels to read.
+        Not implemented for hdf5
     header : `bool`, optional
         Return stored metadata/header as well as map?  Default is False.
         Not implemented for hdf5
@@ -122,20 +126,24 @@ def _read_map_hdf5(healsparse_class, filename, group='map', pixels=None, header=
 
         coverage_pixels = grp['coverage_pixel'][:]
         coverage_values = grp['coverage_value'][:]
-        coverage_mask = np.zeros(coverage_pixels.max() + 1, dtype=bool)
-        coverage_mask[coverage_pixels] = coverage_values
 
-        if pixels is not None:
-            pixels = np.atleast_1d(pixels)
-        else:
-            pixels = grp['pixel'][:]
+        nside_sparse = grp.attrs['nside_sparse']
+        nside_coverage = grp.attrs['nside_coverage']
+
+        cov_map = HealSparseCoverage.make_from_pixels(
+            nside_coverage,
+            nside_sparse,
+            coverage_pixels[coverage_values.astype(bool)]
+        )
+        
+        valid_pixels = grp['pixel'][:]
 
         is_rec_array = grp.attrs.get('is_rec_array', False)
         is_bit_packed = grp.attrs.get('is_bit_packed', False)
         is_wide_mask = grp.attrs.get('is_wide_mask', False)
         wide_mask_width = grp.attrs.get('wide_mask_width', 0)
 
-        # Allocate full sparse map with sentinel
+        # sentinel handling
         sentinel = grp.attrs['sentinel']
         try:
             sentinel = float(sentinel)
@@ -148,6 +156,11 @@ def _read_map_hdf5(healsparse_class, filename, group='map', pixels=None, header=
             elif sentinel == 'True':
                 sentinel = True
 
+        #figure out where in the sparse map each valid pixel should go
+        cov_pix = cov_map.cov_pixels(valid_pixels) #coverage pixel for each valid sparse pixel
+        sparse_index = valid_pixels + cov_map[cov_pix]
+        sparse_size = (sum(cov_map.coverage_mask)+1) * cov_map.nfine_per_cov #sparse map for filled coverage pixels only + 1 overflow 
+
         if is_rec_array:
             dtype = []
             for name in grp:
@@ -155,14 +168,14 @@ def _read_map_hdf5(healsparse_class, filename, group='map', pixels=None, header=
                     continue
                 dtype.append((name, grp[name]['value'].dtype))
 
-            sparse_map = np.zeros(coverage_mask.size, dtype=dtype)
+            sparse_map = np.zeros(sparse_size, dtype=dtype)
             for name, _ in dtype:
                 sparse_map[name][:] = sentinel
-                sparse_map[name][pixels] = grp[name]['value'][:]
+                sparse_map[name][sparse_index] = grp[name]['value'][:]
         else:
             values = grp['value'][:]
-            sparse_map = np.full(coverage_mask.size, sentinel, dtype=values.dtype)
-            sparse_map[pixels] = values
+            sparse_map = np.full(sparse_size, sentinel, dtype=values.dtype)
+            sparse_map[sparse_index] = values
 
             if is_wide_mask:
                 sparse_map = sparse_map.reshape((-1, wide_mask_width)).astype(WIDE_MASK)
@@ -171,11 +184,11 @@ def _read_map_hdf5(healsparse_class, filename, group='map', pixels=None, header=
 
         # metadata
         metadata = {k: grp.attrs[k] for k in grp.attrs
-                        if k not in ['nside_sparse', 'sentinel', 'primary',
+                        if k not in ['nside_sparse', 'nside_coverage', 'sentinel', 'primary',
                                     'nest', 'is_rec_array', 'is_bit_packed',
                                     'is_wide_mask', 'wide_mask_width']}
 
-        hsp_map = healsparse_class(cov_map=coverage_mask,
+        hsp_map = healsparse_class(cov_map=cov_map,
                                      sparse_map=sparse_map,
                                      nside_sparse=grp.attrs['nside_sparse'],
                                      primary=grp.attrs.get('primary', None),

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -139,13 +139,14 @@ def _read_map_hdf5(
     pixels : `list`, optional
         List of coverage map pixels to read.
     header : `bool`, optional
-        Return stored metadata/header as well as map?  Default is False.
+        Return stored metadata/header as well as map?
     degrade_nside : `int`, optional
         Degrade map to this nside on read.
     weightfile : `str`, optional
         Weight map for weighted degrade.
     reduction : `str`, optional
         Reduction method for degrade-on-read.
+
     Returns
     -------
     HealSparseMap instance

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -230,7 +230,6 @@ def _read_map_hdf5(
 
             sparse_map = np.zeros(sparse_size, dtype=dtype)
             for name, _ in dtype:
-                sparse_map[name][:] = sentinel
                 sparse_map[name] = grp[name]["sparse_map"][cov_index_in_sparse_ordered, :][inv].reshape(-1)
         elif is_wide_mask:
             sparse_map = (

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -72,7 +72,19 @@ def _write_map_hdf5(hsp_map, filepath, group="map", clobber=False):
                     compression="gzip",
                 )
         elif hsp_map.is_bit_packed_map:
-            raise RuntimeError("bit packed save to hdf5 not yet implemented")
+            #save as bool array rather than packed to keep the same pixel as other maps when reading
+            sparse_map_reshape = np.asarray(hsp_map._sparse_map).reshape(
+                ncov_in_sparse, nfine_per_cov
+            )
+            #save the bit packed map as a 1D array
+            grp.create_dataset(
+                "sparse_map",
+                data=sparse_map_reshape,
+                chunks=(1, nfine_per_cov),
+                compression="gzip",
+                dtype=bool
+            )
+        
         elif hsp_map.is_wide_mask_map:
             # wide mask, save 2D values
             sparse_map_reshape = hsp_map[name]._sparse_map.reshape(
@@ -243,13 +255,12 @@ def _read_map_hdf5(
                 .astype(WIDE_MASK)
             )
         elif is_bit_packed:
-            raise RuntimeError("bit packed not implemented yet")
-            # sparse_map = _PackedBoolArray(data_buffer=sparse_map)
+            sparse_map = grp["sparse_map"][cov_index_in_sparse_ordered, :][inv].reshape(-1)
+            sparse_map = _PackedBoolArray.from_boolean_array(sparse_map)
+            sentinel = bool(sentinel) #has to be python bool, not numpy bool
         else:
             # is regular map
-            sparse_map = grp["sparse_map"][cov_index_in_sparse_ordered, :][inv].reshape(
-                -1
-            )
+            sparse_map = grp["sparse_map"][cov_index_in_sparse_ordered, :][inv].reshape(-1)
 
         # metadata
         metadata = {

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -108,7 +108,6 @@ def _read_map_hdf5(healsparse_class, filename, group='map', pixels=None, header=
         Not implemented for hdf5
     header : `bool`, optional
         Return stored metadata/header as well as map?  Default is False.
-        returns empty header for hdf5
     degrade_nside : `int`, optional
         Degrade map to this nside on read.
     weightfile : `str`, optional
@@ -193,7 +192,7 @@ def _read_map_hdf5(healsparse_class, filename, group='map', pixels=None, header=
             )
 
         if header:
-            hdr = fits.Header()
+            hdr = fits.Header(hsp_map.metadata)
             return (hsp_map, hdr)
         else:
             return hsp_map

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -9,11 +9,13 @@ import astropy.io.fits as fits
 use_hdf5 = False
 try:
     import h5py
+
     use_hdf5 = True
 except ImportError:
     pass
 
-def _write_map_hdf5(hsp_map, filepath, group='map', clobber=False):
+
+def _write_map_hdf5(hsp_map, filepath, group="map", clobber=False):
     """
     Internal method to write a HealSparseMap to an HDF5 file in a specified group.
 
@@ -32,66 +34,78 @@ def _write_map_hdf5(hsp_map, filepath, group='map', clobber=False):
     """
     if os.path.isfile(filepath) and not clobber:
         raise RuntimeError("Filename %s exists and clobber is False." % (filepath))
-    
-    mode='a' #append mode so we can save to an existing file
+
+    mode = "a"  # append mode so we can save to an existing file
     with h5py.File(filepath, mode) as f:
         if group in f:
             if clobber:
                 del f[group]
             else:
-                raise RuntimeError(f"Group '{group}' in file '{filepath}' exists. Use clobber=True to overwrite.")
+                raise RuntimeError(
+                    f"Group '{group}' in file '{filepath}' exists. Use clobber=True to overwrite."
+                )
         grp = f.create_group(group)
 
         # Coverage map - only save valid pixels
         coverage_pixels = np.where(hsp_map.coverage_mask)[0]
         coverage_values = hsp_map.coverage_mask[coverage_pixels].astype(bool)
-        grp.create_dataset('coverage_pixel', data=coverage_pixels, compression='gzip')
-        grp.create_dataset('coverage_value', data=coverage_values, compression='gzip')
+        grp.create_dataset("coverage_pixel", data=coverage_pixels, compression="gzip")
+        grp.create_dataset("coverage_value", data=coverage_values, compression="gzip")
 
         # Sparse map - only save valid pixels
         valid_pixels = hsp_map.valid_pixels
-        grp.create_dataset('pixel', data=valid_pixels, compression='gzip')
+        grp.create_dataset("pixel", data=valid_pixels, compression="gzip")
 
         if hsp_map.is_rec_array:
             # for recarray, save each field separately
             sparse_values = hsp_map[valid_pixels]
             for name in sparse_values.dtype.names:
                 field_grp = grp.create_group(name)
-                field_grp.create_dataset('value', data=sparse_values[name], compression='gzip')
+                field_grp.create_dataset(
+                    "value", data=sparse_values[name], compression="gzip"
+                )
         elif hsp_map.is_bit_packed_map:
             # for bit-packed, save packed buffer
             sparse_values = hsp_map._sparse_map.data_array[
                 hsp_map._cov_map.cov_index_map[valid_pixels]
             ]
-            grp.create_dataset('value', data=sparse_values, compression='gzip')
+            grp.create_dataset("value", data=sparse_values, compression="gzip")
         elif hsp_map.is_wide_mask_map:
             # wide mask, save 2D values
             sparse_values = hsp_map[valid_pixels]
-            grp.create_dataset('value', data=sparse_values, compression='gzip')
+            grp.create_dataset("value", data=sparse_values, compression="gzip")
         else:
             sparse_values = hsp_map[valid_pixels]
-            grp.create_dataset('value', data=sparse_values, compression='gzip')
+            grp.create_dataset("value", data=sparse_values, compression="gzip")
 
         # Metadata
-        grp.attrs['nside_sparse'] = hsp_map.nside_sparse
-        grp.attrs['nside_coverage'] = hsp_map.nside_coverage
-        grp.attrs['sentinel'] = hsp_map._sentinel
-        grp.attrs['primary'] = '' if hsp_map._primary is None else hsp_map._primary
-        grp.attrs['nest'] = True  # always True
+        grp.attrs["nside_sparse"] = hsp_map.nside_sparse
+        grp.attrs["nside_coverage"] = hsp_map.nside_coverage
+        grp.attrs["sentinel"] = hsp_map._sentinel
+        grp.attrs["primary"] = "" if hsp_map._primary is None else hsp_map._primary
+        grp.attrs["nest"] = True  # always True
 
         # Map type flags
-        grp.attrs['is_rec_array'] = hsp_map.is_rec_array
-        grp.attrs['is_bit_packed'] = hsp_map.is_bit_packed_map
-        grp.attrs['is_wide_mask'] = hsp_map.is_wide_mask_map
-        grp.attrs['wide_mask_width'] = getattr(hsp_map, '_wide_mask_width', 0)
+        grp.attrs["is_rec_array"] = hsp_map.is_rec_array
+        grp.attrs["is_bit_packed"] = hsp_map.is_bit_packed_map
+        grp.attrs["is_wide_mask"] = hsp_map.is_wide_mask_map
+        grp.attrs["wide_mask_width"] = getattr(hsp_map, "_wide_mask_width", 0)
 
         if hsp_map.metadata is not None:
             for k, v in hsp_map.metadata.items():
                 grp.attrs[k] = v
 
 
-def _read_map_hdf5(healsparse_class, filename, group='map', pixels=None, header=False, 
-                   degrade_nside=None, weightfile=None, reduction='mean' ):
+def _read_map_hdf5(
+    healsparse_class,
+    filename,
+    group="map",
+    pixels=None,
+    header=False,
+    degrade_nside=None,
+    weightfile=None,
+    reduction="mean",
+):
     """
     Internal method to read a HealSparseMap from an HDF5 file in a specified group.
 
@@ -119,52 +133,53 @@ def _read_map_hdf5(healsparse_class, filename, group='map', pixels=None, header=
     HealSparseMap instance
     """
     assert pixels is None
-    
-    with h5py.File(filename, 'r') as f:
+
+    with h5py.File(filename, "r") as f:
         if group not in f:
             raise RuntimeError(f"Group '{group}' not found in file '{filename}'")
         grp = f[group]
 
-        coverage_pixels = grp['coverage_pixel'][:]
-        coverage_values = grp['coverage_value'][:]
+        coverage_pixels = grp["coverage_pixel"][:]
+        coverage_values = grp["coverage_value"][:]
 
-        nside_sparse = grp.attrs['nside_sparse']
-        nside_coverage = grp.attrs['nside_coverage']
+        nside_sparse = grp.attrs["nside_sparse"]
+        nside_coverage = grp.attrs["nside_coverage"]
 
         cov_map = HealSparseCoverage.make_from_pixels(
-            nside_coverage,
-            nside_sparse,
-            coverage_pixels[coverage_values.astype(bool)]
+            nside_coverage, nside_sparse, coverage_pixels[coverage_values.astype(bool)]
         )
-        
-        valid_pixels = grp['pixel'][:]
 
-        is_rec_array = grp.attrs.get('is_rec_array', False)
-        is_bit_packed = grp.attrs.get('is_bit_packed', False)
-        is_wide_mask = grp.attrs.get('is_wide_mask', False)
-        wide_mask_width = grp.attrs.get('wide_mask_width', 0)
+        is_rec_array = grp.attrs.get("is_rec_array", False)
+        is_bit_packed = grp.attrs.get("is_bit_packed", False)
+        is_wide_mask = grp.attrs.get("is_wide_mask", False)
+        wide_mask_width = grp.attrs.get("wide_mask_width", 0)
 
         # sentinel handling
-        sentinel = grp.attrs['sentinel']
+        sentinel = grp.attrs["sentinel"]
 
-        #figure out where in the sparse map each valid pixel should go
-        cov_pix = cov_map.cov_pixels(valid_pixels) #coverage pixel for each valid sparse pixel
+        # figure out where in the sparse map each valid pixel should go
+        valid_pixels = grp["pixel"][:]
+        cov_pix = cov_map.cov_pixels(
+            valid_pixels
+        )  # coverage pixel for each valid sparse pixel
         sparse_index = valid_pixels + cov_map[cov_pix]
-        sparse_size = (sum(cov_map.coverage_mask)+1) * cov_map.nfine_per_cov #sparse map for filled coverage pixels only + 1 overflow 
+        sparse_size = (
+            sum(cov_map.coverage_mask) + 1
+        ) * cov_map.nfine_per_cov  # sparse map for filled coverage pixels only + 1 overflow
 
         if is_rec_array:
             dtype = []
             for name in grp:
-                if name in ['pixel', 'coverage_pixel', 'coverage_value']:
+                if name in ["pixel", "coverage_pixel", "coverage_value"]:
                     continue
-                dtype.append((name, grp[name]['value'].dtype))
+                dtype.append((name, grp[name]["value"].dtype))
 
             sparse_map = np.zeros(sparse_size, dtype=dtype)
             for name, _ in dtype:
                 sparse_map[name][:] = sentinel
-                sparse_map[name][sparse_index] = grp[name]['value'][:]
+                sparse_map[name][sparse_index] = grp[name]["value"][:]
         else:
-            values = grp['value'][:]
+            values = grp["value"][:]
             sparse_map = np.full(sparse_size, sentinel, dtype=values.dtype)
             sparse_map[sparse_index] = values
 
@@ -174,23 +189,35 @@ def _read_map_hdf5(healsparse_class, filename, group='map', pixels=None, header=
                 sparse_map = _PackedBoolArray(data_buffer=sparse_map)
 
         # metadata
-        metadata = {k: grp.attrs[k] for k in grp.attrs
-                        if k not in ['nside_sparse', 'nside_coverage', 'sentinel', 'primary',
-                                    'nest', 'is_rec_array', 'is_bit_packed',
-                                    'is_wide_mask', 'wide_mask_width']}
+        metadata = {
+            k: grp.attrs[k]
+            for k in grp.attrs
+            if k
+            not in [
+                "nside_sparse",
+                "nside_coverage",
+                "sentinel",
+                "primary",
+                "nest",
+                "is_rec_array",
+                "is_bit_packed",
+                "is_wide_mask",
+                "wide_mask_width",
+            ]
+        }
 
-        hsp_map = healsparse_class(cov_map=cov_map,
-                                     sparse_map=sparse_map,
-                                     nside_sparse=grp.attrs['nside_sparse'],
-                                     primary=grp.attrs.get('primary', None),
-                                     sentinel=sentinel,
-                                     metadata=metadata)
-    
+        hsp_map = healsparse_class(
+            cov_map=cov_map,
+            sparse_map=sparse_map,
+            nside_sparse=grp.attrs["nside_sparse"],
+            primary=grp.attrs.get("primary", None),
+            sentinel=sentinel,
+            metadata=metadata,
+        )
+
         if degrade_nside is not None:
             hsp_map = hsp_map.degrade(
-                degrade_nside,
-                reduction=reduction,
-                weightfile=weightfile
+                degrade_nside, reduction=reduction, weightfile=weightfile
             )
 
         if header:
@@ -198,7 +225,8 @@ def _read_map_hdf5(healsparse_class, filename, group='map', pixels=None, header=
             return (hsp_map, hdr)
         else:
             return hsp_map
-    
+
+
 def check_hdf5_file(filepath):
     """
     Check if a filepath points to an hdf5 file
@@ -218,8 +246,7 @@ def check_hdf5_file(filepath):
     Warns if hdf5 is not installed.
     """
     if not use_hdf5:
-        warnings.warn("Cannot access hdf5 files without h5py",
-                      UserWarning)
+        warnings.warn("Cannot access hdf5 files without h5py", UserWarning)
         return False
 
     return h5py.is_hdf5(filepath)

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -48,35 +48,53 @@ def _write_map_hdf5(hsp_map, filepath, group="map", clobber=False):
         grp = f.create_group(group)
 
         # Coverage map - save coverage index map
-        grp.create_dataset("cov_index_map", data=hsp_map._cov_map[:], compression="gzip")
+        grp.create_dataset(
+            "cov_index_map", data=hsp_map._cov_map[:], compression="gzip"
+        )
 
         # Sparse map - save the _sparse_map (occupied coverage pixels only+overflow)
         # re-shape sparse_map data so each coverage pixel is a different row
         # chunk the dataset such that each chunk is 1 coverage pixel
-        ncov_in_sparse = sum(hsp_map.coverage_mask) + 1 #include buffer pixel
+        ncov_in_sparse = sum(hsp_map.coverage_mask) + 1  # include buffer pixel
         nfine_per_cov = hsp_map._cov_map._nfine_per_cov
 
         if hsp_map.is_rec_array:
             # for recarray, save each field separately
             for name in hsp_map._sparse_map.dtype.names:
-                sparse_map_reshape = hsp_map[name]._sparse_map.reshape(ncov_in_sparse, nfine_per_cov)
+                sparse_map_reshape = hsp_map[name]._sparse_map.reshape(
+                    ncov_in_sparse, nfine_per_cov
+                )
                 field_grp = grp.create_group(name)
                 field_grp.create_dataset(
-                    "sparse_map", data=sparse_map_reshape, 
-                    chunks=(1, nfine_per_cov), compression="gzip"
+                    "sparse_map",
+                    data=sparse_map_reshape,
+                    chunks=(1, nfine_per_cov),
+                    compression="gzip",
                 )
         elif hsp_map.is_bit_packed_map:
-            raise RuntimeError('bit packed save to hdf5 not yet implemented')
+            raise RuntimeError("bit packed save to hdf5 not yet implemented")
         elif hsp_map.is_wide_mask_map:
             # wide mask, save 2D values
-            sparse_map_reshape = hsp_map[name]._sparse_map.reshape(ncov_in_sparse, nfine_per_cov, hsp_map.wide_mask_width)
-            grp.create_dataset("sparse_map", data=hsp_map._sparse_map, 
-                               chunks=(1, nfine_per_cov, hsp_map.wide_mask_width), compression="gzip")
+            sparse_map_reshape = hsp_map[name]._sparse_map.reshape(
+                ncov_in_sparse, nfine_per_cov, hsp_map.wide_mask_width
+            )
+            grp.create_dataset(
+                "sparse_map",
+                data=hsp_map._sparse_map,
+                chunks=(1, nfine_per_cov, hsp_map.wide_mask_width),
+                compression="gzip",
+            )
         else:
-            #"regular" map
-            sparse_map_reshape = hsp_map._sparse_map.reshape(ncov_in_sparse, nfine_per_cov)
-            grp.create_dataset("sparse_map", data=sparse_map_reshape, 
-                               chunks=(1, nfine_per_cov), compression="gzip")
+            # "regular" map
+            sparse_map_reshape = hsp_map._sparse_map.reshape(
+                ncov_in_sparse, nfine_per_cov
+            )
+            grp.create_dataset(
+                "sparse_map",
+                data=sparse_map_reshape,
+                chunks=(1, nfine_per_cov),
+                compression="gzip",
+            )
 
         # Metadata
         grp.attrs["nside_sparse"] = hsp_map.nside_sparse
@@ -144,7 +162,7 @@ def _read_map_hdf5(
         # this is the coverage map of the *full* map
         cov_map = HealSparseCoverage(cov_index_map, nside_sparse)
 
-        ncov_in_sparse = sum(cov_map.coverage_mask) + 1 #including overflow pixel
+        ncov_in_sparse = sum(cov_map.coverage_mask) + 1  # including overflow pixel
         nfine_per_cov = cov_map._nfine_per_cov
 
         is_rec_array = grp.attrs.get("is_rec_array", False)
@@ -154,46 +172,57 @@ def _read_map_hdf5(
 
         # sentinel handling
         sentinel = grp.attrs["sentinel"]
-        
+
         if pixels is not None:
-            #check the requested pixels are ok
+            # check the requested pixels are ok
             _pixels = np.atleast_1d(pixels)
             if len(np.unique(_pixels)) < len(_pixels):
                 raise RuntimeError("Input list of pixels must be unique.")
 
             # Which pixels are in the coverage map?
-            cov_pix, = np.where(cov_map.coverage_mask)
+            (cov_pix,) = np.where(cov_map.coverage_mask)
             sub = np.clip(np.searchsorted(cov_pix, _pixels), 0, cov_pix.size - 1)
-            ok, = np.where(cov_pix[sub] == _pixels)
+            (ok,) = np.where(cov_pix[sub] == _pixels)
             if ok.size == 0:
-                raise RuntimeError("None of the specified pixels are in the coverage map.")
+                raise RuntimeError(
+                    "None of the specified pixels are in the coverage map."
+                )
             _pixels = np.sort(_pixels[ok])
 
-            #translate the _pixel index to the row in the hdf5 file
-            cov_index_map_temp = cov_map[:] + np.arange(hpg.nside_to_npixel(nside_coverage), dtype=np.int64)*cov_map.nfine_per_cov
-            cov_index_in_sparse = np.append(0, cov_index_map_temp[_pixels]//cov_map.nfine_per_cov) #pixel 0 is the overflow pixel
+            # translate the _pixel index to the row in the hdf5 file
+            cov_index_map_temp = (
+                cov_map[:] +
+                np.arange(hpg.nside_to_npixel(nside_coverage), dtype=np.int64) *
+                cov_map.nfine_per_cov
+            )
+            cov_index_in_sparse = np.append(
+                0, cov_index_map_temp[_pixels] // cov_map.nfine_per_cov
+            )  # pixel 0 is the overflow pixel
 
-            #hdf5 has to read rows in order
+            # hdf5 has to read rows in order
             order = np.argsort(cov_index_in_sparse)
             cov_index_in_sparse_ordered = cov_index_in_sparse[order]
             inv = np.empty_like(order)
             inv[order] = np.arange(order.size)
 
-            #make sub coverage map
+            # make sub coverage map
             _cov_map = HealSparseCoverage.make_from_pixels(
-                    nside_coverage, nside_sparse, _pixels, )
+                nside_coverage,
+                nside_sparse,
+                _pixels,
+            )
 
-            #how many cov pixels(+overflow) are in the sub map
-            ncov_in_sparse_sub = len(_pixels) + 1 
+            # how many cov pixels(+overflow) are in the sub map
+            ncov_in_sparse_sub = len(_pixels) + 1
 
-            sparse_size = ncov_in_sparse_sub*nfine_per_cov
+            sparse_size = ncov_in_sparse_sub * nfine_per_cov
         else:
             cov_index_in_sparse_ordered = slice(None)
             inv = slice(None)
-            sparse_size = ncov_in_sparse*nfine_per_cov
+            sparse_size = ncov_in_sparse * nfine_per_cov
             _cov_map = cov_map
 
-        #load the data
+        # load the data
         if is_rec_array:
             dtype = []
             for name in grp:
@@ -204,15 +233,23 @@ def _read_map_hdf5(
             sparse_map = np.zeros(sparse_size, dtype=dtype)
             for name, _ in dtype:
                 sparse_map[name][:] = sentinel
-                sparse_map[name] = grp[name]["sparse_map"][cov_index_in_sparse_ordered,:][inv].reshape(-1)
+                sparse_map[name] = grp[name]["sparse_map"][
+                    cov_index_in_sparse_ordered, :
+                ][inv].reshape(-1)
         elif is_wide_mask:
-            sparse_map = grp["sparse_map"][cov_index_in_sparse_ordered,:][inv].reshape((-1, wide_mask_width)).astype(WIDE_MASK)
+            sparse_map = (
+                grp["sparse_map"][cov_index_in_sparse_ordered, :][inv]
+                .reshape((-1, wide_mask_width))
+                .astype(WIDE_MASK)
+            )
         elif is_bit_packed:
-            raise RuntimeError('bit packed not implemented yet')
-            #sparse_map = _PackedBoolArray(data_buffer=sparse_map)
+            raise RuntimeError("bit packed not implemented yet")
+            # sparse_map = _PackedBoolArray(data_buffer=sparse_map)
         else:
-            #is regular map
-            sparse_map = grp["sparse_map"][cov_index_in_sparse_ordered,:][inv].reshape(-1)
+            # is regular map
+            sparse_map = grp["sparse_map"][cov_index_in_sparse_ordered, :][inv].reshape(
+                -1
+            )
 
         # metadata
         metadata = {

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -48,9 +48,7 @@ def _write_map_hdf5(hsp_map, filepath, group="map", clobber=False):
         grp = f.create_group(group)
 
         # Coverage map - save coverage index map
-        grp.create_dataset(
-            "cov_index_map", data=hsp_map._cov_map[:], compression="gzip"
-        )
+        grp.create_dataset("cov_index_map", data=hsp_map._cov_map[:], compression="gzip")
 
         # Sparse map - save the _sparse_map (occupied coverage pixels only+overflow)
         # re-shape sparse_map data so each coverage pixel is a different row
@@ -61,9 +59,7 @@ def _write_map_hdf5(hsp_map, filepath, group="map", clobber=False):
         if hsp_map.is_rec_array:
             # for recarray, save each field separately
             for name in hsp_map._sparse_map.dtype.names:
-                sparse_map_reshape = hsp_map[name]._sparse_map.reshape(
-                    ncov_in_sparse, nfine_per_cov
-                )
+                sparse_map_reshape = hsp_map[name]._sparse_map.reshape(ncov_in_sparse, nfine_per_cov)
                 field_grp = grp.create_group(name)
                 field_grp.create_dataset(
                     "sparse_map",
@@ -72,19 +68,17 @@ def _write_map_hdf5(hsp_map, filepath, group="map", clobber=False):
                     compression="gzip",
                 )
         elif hsp_map.is_bit_packed_map:
-            #save as bool array rather than packed to keep the same pixel as other maps when reading
-            sparse_map_reshape = np.asarray(hsp_map._sparse_map).reshape(
-                ncov_in_sparse, nfine_per_cov
-            )
-            #save the bit packed map as a 1D array
+            # save as bool array rather than packed to keep the same pixel as other maps when reading
+            sparse_map_reshape = np.asarray(hsp_map._sparse_map).reshape(ncov_in_sparse, nfine_per_cov)
+            # save the bit packed map as a 1D array
             grp.create_dataset(
                 "sparse_map",
                 data=sparse_map_reshape,
                 chunks=(1, nfine_per_cov),
                 compression="gzip",
-                dtype=bool
+                dtype=bool,
             )
-        
+
         elif hsp_map.is_wide_mask_map:
             # wide mask, save 2D values
             sparse_map_reshape = hsp_map[name]._sparse_map.reshape(
@@ -98,9 +92,7 @@ def _write_map_hdf5(hsp_map, filepath, group="map", clobber=False):
             )
         else:
             # "regular" map
-            sparse_map_reshape = hsp_map._sparse_map.reshape(
-                ncov_in_sparse, nfine_per_cov
-            )
+            sparse_map_reshape = hsp_map._sparse_map.reshape(ncov_in_sparse, nfine_per_cov)
             grp.create_dataset(
                 "sparse_map",
                 data=sparse_map_reshape,
@@ -196,16 +188,13 @@ def _read_map_hdf5(
             sub = np.clip(np.searchsorted(cov_pix, _pixels), 0, cov_pix.size - 1)
             (ok,) = np.where(cov_pix[sub] == _pixels)
             if ok.size == 0:
-                raise RuntimeError(
-                    "None of the specified pixels are in the coverage map."
-                )
+                raise RuntimeError("None of the specified pixels are in the coverage map.")
             _pixels = np.sort(_pixels[ok])
 
             # translate the _pixel index to the row in the hdf5 file
             cov_index_map_temp = (
-                cov_map[:] +
-                np.arange(hpg.nside_to_npixel(nside_coverage), dtype=np.int64) *
-                cov_map.nfine_per_cov
+                cov_map[:]
+                + np.arange(hpg.nside_to_npixel(nside_coverage), dtype=np.int64) * cov_map.nfine_per_cov
             )
             cov_index_in_sparse = np.append(
                 0, cov_index_map_temp[_pixels] // cov_map.nfine_per_cov
@@ -245,9 +234,7 @@ def _read_map_hdf5(
             sparse_map = np.zeros(sparse_size, dtype=dtype)
             for name, _ in dtype:
                 sparse_map[name][:] = sentinel
-                sparse_map[name] = grp[name]["sparse_map"][
-                    cov_index_in_sparse_ordered, :
-                ][inv].reshape(-1)
+                sparse_map[name] = grp[name]["sparse_map"][cov_index_in_sparse_ordered, :][inv].reshape(-1)
         elif is_wide_mask:
             sparse_map = (
                 grp["sparse_map"][cov_index_in_sparse_ordered, :][inv]
@@ -257,7 +244,7 @@ def _read_map_hdf5(
         elif is_bit_packed:
             sparse_map = grp["sparse_map"][cov_index_in_sparse_ordered, :][inv].reshape(-1)
             sparse_map = _PackedBoolArray.from_boolean_array(sparse_map)
-            sentinel = bool(sentinel) #has to be python bool, not numpy bool
+            sentinel = bool(sentinel)  # has to be python bool, not numpy bool
         else:
             # is regular map
             sparse_map = grp["sparse_map"][cov_index_in_sparse_ordered, :][inv].reshape(-1)
@@ -290,9 +277,7 @@ def _read_map_hdf5(
         )
 
         if degrade_nside is not None:
-            hsp_map = hsp_map.degrade(
-                degrade_nside, reduction=reduction, weightfile=weightfile
-            )
+            hsp_map = hsp_map.degrade(degrade_nside, reduction=reduction, weightfile=weightfile)
 
         if header:
             hdr = fits.Header(hsp_map.metadata)

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -67,14 +67,14 @@ def _write_map_hdf5(hsp_map, filepath, hdf5_group="map", clobber=False):
                 )
         elif hsp_map.is_bit_packed_map:
             # save as bool array rather than packed to keep the same pixel as other maps when reading
-            sparse_map_reshape = np.asarray(hsp_map._sparse_map).reshape(ncov_in_sparse, nfine_per_cov)
+            sparse_map_reshape = hsp_map._sparse_map.data_array.reshape(ncov_in_sparse, nfine_per_cov//8)
             # save the bit packed map as a 1D array
             grp.create_dataset(
                 "sparse_map",
                 data=sparse_map_reshape,
-                chunks=(1, nfine_per_cov),
+                chunks=(1, nfine_per_cov//8),
                 compression="gzip",
-                dtype=bool,
+                dtype=np.uint8,
             )
 
         elif hsp_map.is_wide_mask_map:
@@ -239,8 +239,8 @@ def _read_map_hdf5(
                 .astype(WIDE_MASK)
             )
         elif is_bit_packed:
-            sparse_map = grp["sparse_map"][cov_index_in_sparse_ordered, :][inv].reshape(-1)
-            sparse_map = _PackedBoolArray.from_boolean_array(sparse_map)
+            bit_packed_map = grp["sparse_map"][cov_index_in_sparse_ordered, :][inv].reshape(-1)
+            sparse_map = _PackedBoolArray(data_buffer=bit_packed_map)
             sentinel = bool(sentinel)  # has to be python bool, not numpy bool
         else:
             # is regular map

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -25,13 +25,13 @@ def _write_map_hdf5(hsp_map, filepath, group="map", clobber=False):
     Parameters
     ----------
     hsp_map : HealSparseMap
-        Map to save
+        Map to save.
     filepath : str
-        HDF5 file path
+        HDF5 file path.
     group : str, optional
-        Name of the HDF5 group to store the map (default 'map')
+        Name of the HDF5 group to store the map.
     clobber : bool, optional
-        Overwrite the file/group if it exists (default False)
+        Overwrite the file/group if it exists.
     """
     if os.path.isfile(filepath) and not clobber:
         raise RuntimeError("Filename %s exists and clobber is False." % (filepath))
@@ -141,7 +141,6 @@ def _read_map_hdf5(
         HDF5 group containing the map
     pixels : `list`, optional
         List of coverage map pixels to read.
-        Not implemented for hdf5
     header : `bool`, optional
         Return stored metadata/header as well as map?  Default is False.
     degrade_nside : `int`, optional
@@ -298,7 +297,7 @@ def check_hdf5_file(filepath):
     Returns
     -------
     is_hdf5_file : `bool`
-        True if it is an hdf5 file
+        True if it is an hdf5 file.
 
     Raises
     ------

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -4,7 +4,7 @@ from .utils import WIDE_MASK
 from .packedBoolArray import _PackedBoolArray
 import warnings
 from .healSparseCoverage import HealSparseCoverage
-import healpy as hp
+import astropy.io.fits as fits
 
 use_hdf5 = False
 try:
@@ -108,7 +108,7 @@ def _read_map_hdf5(healsparse_class, filename, group='map', pixels=None, header=
         Not implemented for hdf5
     header : `bool`, optional
         Return stored metadata/header as well as map?  Default is False.
-        Not implemented for hdf5
+        returns empty header for hdf5
     degrade_nside : `int`, optional
         Degrade map to this nside on read.
     weightfile : `str`, optional
@@ -202,7 +202,11 @@ def _read_map_hdf5(healsparse_class, filename, group='map', pixels=None, header=
                 weightfile=weightfile
             )
 
-        return hsp_map
+        if header:
+            hdr = fits.Header()
+            return (hsp_map, hdr)
+        else:
+            return hsp_map
     
 def check_hdf5_file(filepath):
     """

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -118,6 +118,8 @@ def _read_map_hdf5(healsparse_class, filename, group='map', pixels=None, header=
     -------
     HealSparseMap instance
     """
+    assert pixels is None
+    
     with h5py.File(filename, 'r') as f:
         if group not in f:
             raise RuntimeError(f"Group '{group}' not found in file '{filename}'")

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -34,12 +34,12 @@ def _write_map_hdf5(hsp_map, filepath, hdf5_group="map", clobber=False):
         Overwrite the file/group if it exists.
     """
     if os.path.isfile(filepath) and not clobber:
-        with h5py.File(filepath, mode) as f:
+        with h5py.File(filepath, 'r') as f:
             group_exists = hdf5_group in f
         if group_exists:
             raise RuntimeError(f"Filename {filepath} with group {hdf5_group} exists and clobber is False.")
 
-    mode = "a"  # append mode so we can save to an existing file if we want
+    mode = "a"  # append mode, if file doesn't exist it will be made
     with h5py.File(filepath, mode) as f:
         if hdf5_group in f and clobber:
             del f[hdf5_group]
@@ -190,8 +190,8 @@ def _read_map_hdf5(
 
             # translate the _pixel index to the row in the hdf5 file
             cov_index_map_temp = (
-                cov_map[:]
-                + np.arange(hpg.nside_to_npixel(nside_coverage), dtype=np.int64) * cov_map.nfine_per_cov
+                cov_map[:] +
+                np.arange(hpg.nside_to_npixel(nside_coverage), dtype=np.int64) * cov_map.nfine_per_cov
             )
             cov_index_in_sparse = np.append(
                 0, cov_index_map_temp[_pixels] // cov_map.nfine_per_cov

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -16,7 +16,7 @@ except ImportError:
     pass
 
 
-def _write_map_hdf5(hsp_map, filepath, group="map", clobber=False):
+def _write_map_hdf5(hsp_map, filepath, hdf5_group="map", clobber=False):
     """
     Internal method to write a HealSparseMap to an HDF5 file in a specified group.
 
@@ -28,27 +28,22 @@ def _write_map_hdf5(hsp_map, filepath, group="map", clobber=False):
         Map to save.
     filepath : str
         HDF5 file path.
-    group : str, optional
+    hdf5_group : str, optional
         Name of the HDF5 group to store the map.
     clobber : bool, optional
         Overwrite the file/group if it exists.
     """
     if os.path.isfile(filepath) and not clobber:
         with h5py.File(filepath, mode) as f:
-            group_exists = group in f.keys()
+            group_exists = hdf5_group in f
         if group_exists:
-            raise RuntimeError(f"Filename {filepath} with group {group} exists and clobber is False.")
+            raise RuntimeError(f"Filename {filepath} with group {hdf5_group} exists and clobber is False.")
 
     mode = "a"  # append mode so we can save to an existing file if we want
     with h5py.File(filepath, mode) as f:
-        if group in f:
-            if clobber:
-                del f[group]
-            else:
-                raise RuntimeError(
-                    f"Group '{group}' in file '{filepath}' exists. Use clobber=True to overwrite."
-                )
-        grp = f.create_group(group)
+        if hdf5_group in f and clobber:
+            del f[hdf5_group]
+        grp = f.create_group(hdf5_group)
 
         # Coverage map - save coverage index map
         grp.create_dataset("cov_index_map", data=hsp_map._cov_map[:], compression="gzip")
@@ -124,7 +119,7 @@ def _write_map_hdf5(hsp_map, filepath, group="map", clobber=False):
 def _read_map_hdf5(
     healsparse_class,
     filename,
-    group="map",
+    hdf5_group="map",
     pixels=None,
     header=False,
     degrade_nside=None,
@@ -157,9 +152,9 @@ def _read_map_hdf5(
     HealSparseMap instance
     """
     with h5py.File(filename, "r") as f:
-        if group not in f:
-            raise RuntimeError(f"Group '{group}' not found in file '{filename}'")
-        grp = f[group]
+        if hdf5_group not in f:
+            raise RuntimeError(f"Group '{hdf5_group}' not found in file '{filename}'")
+        grp = f[hdf5_group]
 
         cov_index_map = grp["cov_index_map"][:]
         nside_sparse = grp.attrs["nside_sparse"]

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -52,31 +52,33 @@ def _write_map_hdf5(hsp_map, filepath, group="map", clobber=False):
         grp.create_dataset("coverage_pixel", data=coverage_pixels, compression="gzip")
         grp.create_dataset("coverage_value", data=coverage_values, compression="gzip")
 
-        # Sparse map - only save valid pixels
-        valid_pixels = hsp_map.valid_pixels
-        grp.create_dataset("pixel", data=valid_pixels, compression="gzip")
+        # Sparse map - save the _sparse_map (occupied coverage pixels only+overflow)
+        # re-shape sparse_map data so each coverage pixel is a different row
+        # chunk the dataset such that each chunk is 1 coverage pixel
+        ncov_in_sparse = sum(hsp_map.coverage_mask) + 1 #include buffer pixel
+        nfine_per_cov = hsp_map._cov_map._nfine_per_cov
 
         if hsp_map.is_rec_array:
             # for recarray, save each field separately
-            sparse_values = hsp_map[valid_pixels]
-            for name in sparse_values.dtype.names:
+            for name in hsp_map._sparse_map.dtype.names:
+                sparse_map_reshape = hsp_map[name]._sparse_map.reshape(ncov_in_sparse, nfine_per_cov)
                 field_grp = grp.create_group(name)
                 field_grp.create_dataset(
-                    "value", data=sparse_values[name], compression="gzip"
+                    "sparse_map", data=sparse_map_reshape, 
+                    chunks=(1, nfine_per_cov), compression="gzip"
                 )
         elif hsp_map.is_bit_packed_map:
-            # for bit-packed, save packed buffer
-            sparse_values = hsp_map._sparse_map.data_array[
-                hsp_map._cov_map.cov_index_map[valid_pixels]
-            ]
-            grp.create_dataset("value", data=sparse_values, compression="gzip")
+            raise RuntimeError('bit packed save to hdf5 not yet implemented')
         elif hsp_map.is_wide_mask_map:
             # wide mask, save 2D values
-            sparse_values = hsp_map[valid_pixels]
-            grp.create_dataset("value", data=sparse_values, compression="gzip")
+            sparse_map_reshape = hsp_map[name]._sparse_map.reshape(ncov_in_sparse, nfine_per_cov, hsp_map.wide_mask_width)
+            grp.create_dataset("sparse_map", data=hsp_map._sparse_map, 
+                               chunks=(1, nfine_per_cov, hsp_map.wide_mask_width), compression="gzip")
         else:
-            sparse_values = hsp_map[valid_pixels]
-            grp.create_dataset("value", data=sparse_values, compression="gzip")
+            #"regular" map
+            sparse_map_reshape = hsp_map._sparse_map.reshape(ncov_in_sparse, nfine_per_cov)
+            grp.create_dataset("sparse_map", data=sparse_map_reshape, 
+                               chunks=(1, nfine_per_cov), compression="gzip")
 
         # Metadata
         grp.attrs["nside_sparse"] = hsp_map.nside_sparse
@@ -132,8 +134,6 @@ def _read_map_hdf5(
     -------
     HealSparseMap instance
     """
-    assert pixels is None
-
     with h5py.File(filename, "r") as f:
         if group not in f:
             raise RuntimeError(f"Group '{group}' not found in file '{filename}'")
@@ -145,9 +145,13 @@ def _read_map_hdf5(
         nside_sparse = grp.attrs["nside_sparse"]
         nside_coverage = grp.attrs["nside_coverage"]
 
+        # this is the coverage map of the *full* map
         cov_map = HealSparseCoverage.make_from_pixels(
             nside_coverage, nside_sparse, coverage_pixels[coverage_values.astype(bool)]
         )
+
+        ncov_in_sparse = sum(cov_map.coverage_mask) + 1 #including overflow pixel
+        nfine_per_cov = cov_map._nfine_per_cov
 
         is_rec_array = grp.attrs.get("is_rec_array", False)
         is_bit_packed = grp.attrs.get("is_bit_packed", False)
@@ -156,37 +160,58 @@ def _read_map_hdf5(
 
         # sentinel handling
         sentinel = grp.attrs["sentinel"]
+        
+        if pixels is not None:
+            #check the requested pixels are ok
+            _pixels = np.atleast_1d(pixels)
+            if len(np.unique(_pixels)) < len(_pixels):
+                raise RuntimeError("Input list of pixels must be unique.")
 
-        # figure out where in the sparse map each valid pixel should go
-        valid_pixels = grp["pixel"][:]
-        cov_pix = cov_map.cov_pixels(
-            valid_pixels
-        )  # coverage pixel for each valid sparse pixel
-        sparse_index = valid_pixels + cov_map[cov_pix]
-        sparse_size = (
-            sum(cov_map.coverage_mask) + 1
-        ) * cov_map.nfine_per_cov  # sparse map for filled coverage pixels only + 1 overflow
+            # Which pixels are in the coverage map?
+            cov_pix, = np.where(cov_map.coverage_mask)
+            sub = np.clip(np.searchsorted(cov_pix, _pixels), 0, cov_pix.size - 1)
+            ok, = np.where(cov_pix[sub] == _pixels)
+            if ok.size == 0:
+                raise RuntimeError("None of the specified pixels are in the coverage map.")
+            _pixels = np.sort(_pixels[ok])
 
+            #translate the _pixel index to the row in the hdf5 file
+            # we always want index 0 first as this is the overfow pixel 
+            cov_index_in_sparse = np.append(0, np.searchsorted(cov_pix, _pixels) + 1)
+
+            #make sub coverage map
+            _cov_map = HealSparseCoverage.make_from_pixels(
+                    nside_coverage, nside_sparse, _pixels, )
+
+            #how many cov pixels(+overflow) are in the sub map
+            ncov_in_sparse_sub = len(_pixels) + 1 
+
+            sparse_size = ncov_in_sparse_sub*nfine_per_cov
+        else:
+            cov_index_in_sparse = slice(None)
+            sparse_size = ncov_in_sparse*nfine_per_cov
+            _cov_map = cov_map
+
+        #load the data
         if is_rec_array:
             dtype = []
             for name in grp:
-                if name in ["pixel", "coverage_pixel", "coverage_value"]:
+                if name in ["coverage_pixel", "coverage_value"]:
                     continue
-                dtype.append((name, grp[name]["value"].dtype))
+                dtype.append((name, grp[name]["sparse_map"].dtype))
 
             sparse_map = np.zeros(sparse_size, dtype=dtype)
             for name, _ in dtype:
                 sparse_map[name][:] = sentinel
-                sparse_map[name][sparse_index] = grp[name]["value"][:]
+                sparse_map[name] = grp[name]["sparse_map"][cov_index_in_sparse,:].reshape(-1)
+        elif is_wide_mask:
+            sparse_map = grp["sparse_map"][cov_index_in_sparse,:].reshape((-1, wide_mask_width)).astype(WIDE_MASK)
+        elif is_bit_packed:
+            raise RuntimeError('bit packed not implemented yet')
+            #sparse_map = _PackedBoolArray(data_buffer=sparse_map)
         else:
-            values = grp["value"][:]
-            sparse_map = np.full(sparse_size, sentinel, dtype=values.dtype)
-            sparse_map[sparse_index] = values
-
-            if is_wide_mask:
-                sparse_map = sparse_map.reshape((-1, wide_mask_width)).astype(WIDE_MASK)
-            elif is_bit_packed:
-                sparse_map = _PackedBoolArray(data_buffer=sparse_map)
+            #is regular map
+            sparse_map = grp["sparse_map"][cov_index_in_sparse,:].reshape(-1)
 
         # metadata
         metadata = {
@@ -207,7 +232,7 @@ def _read_map_hdf5(
         }
 
         hsp_map = healsparse_class(
-            cov_map=cov_map,
+            cov_map=_cov_map,
             sparse_map=sparse_map,
             nside_sparse=grp.attrs["nside_sparse"],
             primary=grp.attrs.get("primary", None),

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -5,6 +5,7 @@ from .packedBoolArray import _PackedBoolArray
 import warnings
 from .healSparseCoverage import HealSparseCoverage
 import astropy.io.fits as fits
+import hpgeom as hpg
 
 use_hdf5 = False
 try:
@@ -169,8 +170,14 @@ def _read_map_hdf5(
             _pixels = np.sort(_pixels[ok])
 
             #translate the _pixel index to the row in the hdf5 file
-            # we always want index 0 first as this is the overfow pixel 
-            cov_index_in_sparse = np.append(0, np.searchsorted(cov_pix, _pixels) + 1)
+            cov_index_map_temp = cov_map[:] + np.arange(hpg.nside_to_npixel(nside_coverage), dtype=np.int64)*cov_map.nfine_per_cov
+            cov_index_in_sparse = np.append(0, cov_index_map_temp[_pixels]//cov_map.nfine_per_cov) #pixel 0 is the overflow pixel
+
+            #hdf5 has to read rows in order
+            order = np.argsort(cov_index_in_sparse)
+            cov_index_in_sparse_ordered = cov_index_in_sparse[order]
+            inv = np.empty_like(order)
+            inv[order] = np.arange(order.size)
 
             #make sub coverage map
             _cov_map = HealSparseCoverage.make_from_pixels(
@@ -181,7 +188,8 @@ def _read_map_hdf5(
 
             sparse_size = ncov_in_sparse_sub*nfine_per_cov
         else:
-            cov_index_in_sparse = slice(None)
+            cov_index_in_sparse_ordered = slice(None)
+            inv = slice(None)
             sparse_size = ncov_in_sparse*nfine_per_cov
             _cov_map = cov_map
 
@@ -196,15 +204,15 @@ def _read_map_hdf5(
             sparse_map = np.zeros(sparse_size, dtype=dtype)
             for name, _ in dtype:
                 sparse_map[name][:] = sentinel
-                sparse_map[name] = grp[name]["sparse_map"][cov_index_in_sparse,:].reshape(-1)
+                sparse_map[name] = grp[name]["sparse_map"][cov_index_in_sparse_ordered,:][inv].reshape(-1)
         elif is_wide_mask:
-            sparse_map = grp["sparse_map"][cov_index_in_sparse,:].reshape((-1, wide_mask_width)).astype(WIDE_MASK)
+            sparse_map = grp["sparse_map"][cov_index_in_sparse_ordered,:][inv].reshape((-1, wide_mask_width)).astype(WIDE_MASK)
         elif is_bit_packed:
             raise RuntimeError('bit packed not implemented yet')
             #sparse_map = _PackedBoolArray(data_buffer=sparse_map)
         else:
             #is regular map
-            sparse_map = grp["sparse_map"][cov_index_in_sparse,:].reshape(-1)
+            sparse_map = grp["sparse_map"][cov_index_in_sparse_ordered,:][inv].reshape(-1)
 
         # metadata
         metadata = {

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -46,11 +46,8 @@ def _write_map_hdf5(hsp_map, filepath, group="map", clobber=False):
                 )
         grp = f.create_group(group)
 
-        # Coverage map - only save valid pixels
-        coverage_pixels = np.where(hsp_map.coverage_mask)[0]
-        coverage_values = hsp_map.coverage_mask[coverage_pixels].astype(bool)
-        grp.create_dataset("coverage_pixel", data=coverage_pixels, compression="gzip")
-        grp.create_dataset("coverage_value", data=coverage_values, compression="gzip")
+        # Coverage map - save coverage index map
+        grp.create_dataset("cov_index_map", data=hsp_map._cov_map[:], compression="gzip")
 
         # Sparse map - save the _sparse_map (occupied coverage pixels only+overflow)
         # re-shape sparse_map data so each coverage pixel is a different row
@@ -139,16 +136,12 @@ def _read_map_hdf5(
             raise RuntimeError(f"Group '{group}' not found in file '{filename}'")
         grp = f[group]
 
-        coverage_pixels = grp["coverage_pixel"][:]
-        coverage_values = grp["coverage_value"][:]
-
+        cov_index_map = grp["cov_index_map"][:]
         nside_sparse = grp.attrs["nside_sparse"]
         nside_coverage = grp.attrs["nside_coverage"]
 
         # this is the coverage map of the *full* map
-        cov_map = HealSparseCoverage.make_from_pixels(
-            nside_coverage, nside_sparse, coverage_pixels[coverage_values.astype(bool)]
-        )
+        cov_map = HealSparseCoverage(cov_index_map, nside_sparse)
 
         ncov_in_sparse = sum(cov_map.coverage_mask) + 1 #including overflow pixel
         nfine_per_cov = cov_map._nfine_per_cov

--- a/healsparse/io_map_hdf5.py
+++ b/healsparse/io_map_hdf5.py
@@ -1,0 +1,164 @@
+import h5py
+import os
+import numpy as np
+from .utils import WIDE_MASK
+from .packedBoolArray import _PackedBoolArray
+
+def _write_map_hdf5(hsp_map, filepath, group='map', clobber=False):
+    """
+    Internal method to write a HealSparseMap to an HDF5 file in a specified group.
+
+    Supports regular, recarray, wide-mask, and bit-packed maps.
+
+    Parameters
+    ----------
+    hsp_map : HealSparseMap
+        Map to save
+    filepath : str
+        HDF5 file path
+    group : str, optional
+        Name of the HDF5 group to store the map (default 'map')
+    clobber : bool, optional
+        Overwrite the file/group if it exists (default False)
+    """
+    if os.path.isfile(filepath) and not clobber:
+        raise RuntimeError("Filename %s exists and clobber is False." % (filepath))
+    
+    mode='a' #append mode so we can save to an existing file
+    with h5py.File(filepath, mode) as f:
+        if group in f:
+            if clobber:
+                del f[group]
+            else:
+                raise RuntimeError(f"Group '{group}' in file '{filepath}' exists. Use clobber=True to overwrite.")
+        grp = f.create_group(group)
+
+        # Coverage map - only save valid pixels
+        coverage_pixels = np.where(hsp_map.coverage_mask)[0]
+        coverage_values = hsp_map.coverage_mask[coverage_pixels].astype(bool)
+        grp.create_dataset('coverage_pixel', data=coverage_pixels, compression='gzip')
+        grp.create_dataset('coverage_value', data=coverage_values, compression='gzip')
+
+        # Sparse map - only save valid pixels
+        valid_pixels = hsp_map.valid_pixels
+        grp.create_dataset('pixel', data=valid_pixels, compression='gzip')
+
+        if hsp_map.is_rec_array:
+            # for recarray, save each field separately
+            sparse_values = hsp_map[valid_pixels]
+            for name in sparse_values.dtype.names:
+                field_grp = grp.create_group(name)
+                field_grp.create_dataset('value', data=sparse_values[name], compression='gzip')
+        elif hsp_map.is_bit_packed_map:
+            # for bit-packed, save packed buffer
+            sparse_values = hsp_map._sparse_map.data_array[
+                hsp_map._cov_map.cov_index_map[valid_pixels]
+            ]
+            grp.create_dataset('value', data=sparse_values, compression='gzip')
+        elif hsp_map.is_wide_mask_map:
+            # wide mask, save 2D values
+            sparse_values = hsp_map[valid_pixels]
+            grp.create_dataset('value', data=sparse_values, compression='gzip')
+        else:
+            sparse_values = hsp_map[valid_pixels]
+            grp.create_dataset('value', data=sparse_values, compression='gzip')
+
+        # Metadata
+        grp.attrs['nside_sparse'] = hsp_map._nside_sparse
+        grp.attrs['sentinel'] = float(hsp_map._sentinel) if np.isscalar(hsp_map._sentinel) else str(hsp_map._sentinel)
+        grp.attrs['primary'] = '' if hsp_map._primary is None else hsp_map._primary
+        grp.attrs['nest'] = True  # always True
+
+        # Map type flags
+        grp.attrs['is_rec_array'] = hsp_map.is_rec_array
+        grp.attrs['is_bit_packed'] = hsp_map.is_bit_packed_map
+        grp.attrs['is_wide_mask'] = hsp_map.is_wide_mask_map
+        grp.attrs['wide_mask_width'] = getattr(hsp_map, '_wide_mask_width', 0)
+
+        if hsp_map.metadata is not None:
+            for k, v in hsp_map.metadata.items():
+                grp.attrs[k] = str(v)
+
+
+def read_map_hdf5(healsparse_class, filename, group='map'):
+    """
+    Internal method to read a HealSparseMap from an HDF5 file in a specified group.
+
+    Parameters
+    ----------
+    healsparse_class : class
+        HealSparseMap class
+    filename : str
+        HDF5 file path
+    group : str
+        HDF5 group containing the map
+
+    Returns
+    -------
+    HealSparseMap instance
+    """
+    with h5py.File(filename, 'r') as f:
+        if group not in f:
+            raise RuntimeError(f"Group '{group}' not found in file '{filename}'")
+        grp = f[group]
+
+        coverage_pixels = grp['coverage_pixel'][:]
+        coverage_values = grp['coverage_value'][:]
+        coverage_mask = np.zeros(coverage_pixels.max() + 1, dtype=bool)
+        coverage_mask[coverage_pixels] = coverage_values
+
+        pixels = grp['pixel'][:]
+
+        is_rec_array = grp.attrs.get('is_rec_array', False)
+        is_bit_packed = grp.attrs.get('is_bit_packed', False)
+        is_wide_mask = grp.attrs.get('is_wide_mask', False)
+        wide_mask_width = grp.attrs.get('wide_mask_width', 0)
+
+        # Allocate full sparse map with sentinel
+        sentinel = grp.attrs['sentinel']
+        try:
+            sentinel = float(sentinel)
+        except ValueError:
+            if sentinel == 'UNSEEN':
+                import hpgeom as hpg
+                sentinel = hpg.UNSEEN
+            elif sentinel == 'False':
+                sentinel = False
+            elif sentinel == 'True':
+                sentinel = True
+
+        if is_rec_array:
+            dtype = []
+            for name in grp:
+                if name in ['pixel', 'coverage_pixel', 'coverage_value']:
+                    continue
+                dtype.append((name, grp[name]['value'].dtype))
+
+            sparse_map = np.zeros(coverage_mask.size, dtype=dtype)
+            for name, _ in dtype:
+                sparse_map[name][:] = sentinel
+                sparse_map[name][pixels] = grp[name]['value'][:]
+        else:
+            values = grp['value'][:]
+            sparse_map = np.full(coverage_mask.size, sentinel, dtype=values.dtype)
+            sparse_map[pixels] = values
+
+            if is_wide_mask:
+                sparse_map = sparse_map.reshape((-1, wide_mask_width)).astype(WIDE_MASK)
+            elif is_bit_packed:
+                sparse_map = _PackedBoolArray(data_buffer=sparse_map)
+
+        # User metadata
+        user_metadata = {k: grp.attrs[k] for k in grp.attrs
+                         if k not in ['nside_sparse', 'sentinel', 'primary',
+                                      'nest', 'is_rec_array', 'is_bit_packed',
+                                      'is_wide_mask', 'wide_mask_width']}
+
+        hsp_map = healsparse_class(cov_map=coverage_mask,
+                                     sparse_map=sparse_map,
+                                     nside_sparse=grp.attrs['nside_sparse'],
+                                     primary=grp.attrs.get('primary', None),
+                                     sentinel=sentinel,
+                                     metadata=user_metadata)
+
+        return hsp_map

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,8 @@ test_with_healpy =
   healpy
 fitsio =
   fitsio
+hdf5 =
+    h5py
 
 [options.packages.find]
 exclude =

--- a/tests/test_io_hdf5.py
+++ b/tests/test_io_hdf5.py
@@ -10,8 +10,9 @@ import pathlib
 
 import healsparse
 
-#read specific coverage pixels not yet implemented
+# read specific coverage pixels not yet implemented
 test_pixels_read = False
+
 
 class Hdf5IoTestCase(unittest.TestCase):
     def test_hdf5_writeread(self):
@@ -27,7 +28,7 @@ class Hdf5IoTestCase(unittest.TestCase):
         ra = np.random.random(n_rand) * 360.0
         dec = np.random.random(n_rand) * 180.0 - 90.0
 
-        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
+        self.test_dir = tempfile.mkdtemp(dir="./", prefix="TestHealSparse-")
 
         # Generate a random map
         full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
@@ -37,11 +38,9 @@ class Hdf5IoTestCase(unittest.TestCase):
         test_values = full_map[ipnest]
 
         sparse_map = healsparse.HealSparseMap.make_empty(
-            nside_coverage,
-            nside_map,
-            full_map.dtype
+            nside_coverage, nside_map, full_map.dtype
         )
-        u, = np.where(full_map > hpg.UNSEEN)
+        (u,) = np.where(full_map > hpg.UNSEEN)
         sparse_map[u] = full_map[u]
 
         for mode in ("str", "path"):
@@ -56,41 +55,28 @@ class Hdf5IoTestCase(unittest.TestCase):
             # Read full map
             sparse_map2 = healsparse.HealSparseMap.read(fname)
 
-            testing.assert_almost_equal(
-                sparse_map2.get_values_pix(ipnest),
-                test_values
-            )
+            testing.assert_almost_equal(sparse_map2.get_values_pix(ipnest), test_values)
 
             if test_pixels_read:
-            # Non-unique pixels should error
+                # Non-unique pixels should error
                 self.assertRaises(
-                    RuntimeError,
-                    healsparse.HealSparseMap.read,
-                    fname,
-                    pixels=[0, 0]
+                    RuntimeError, healsparse.HealSparseMap.read, fname, pixels=[0, 0]
                 )
 
                 # Read two coverage pixels
-                sparse_map_small = healsparse.HealSparseMap.read(
-                    fname,
-                    pixels=[0, 1]
-                )
+                sparse_map_small = healsparse.HealSparseMap.read(fname, pixels=[0, 1])
 
                 cov_mask = sparse_map_small.coverage_mask
                 self.assertEqual(cov_mask.sum(), 2)
 
-                ipnest_cov = np.right_shift(
-                    ipnest,
-                    sparse_map_small._cov_map.bit_shift
-                )
+                ipnest_cov = np.right_shift(ipnest, sparse_map_small._cov_map.bit_shift)
 
                 test_values2 = test_values.copy()
-                outside_small, = np.where(ipnest_cov > 1)
+                (outside_small,) = np.where(ipnest_cov > 1)
                 test_values2[outside_small] = hpg.UNSEEN
 
                 testing.assert_almost_equal(
-                    sparse_map_small.get_values_pix(ipnest),
-                    test_values2
+                    sparse_map_small.get_values_pix(ipnest), test_values2
                 )
 
                 # Read all coverage pixels explicitly
@@ -100,8 +86,7 @@ class Hdf5IoTestCase(unittest.TestCase):
                 )
 
                 testing.assert_almost_equal(
-                    sparse_map_full.get_values_pix(ipnest),
-                    test_values
+                    sparse_map_full.get_values_pix(ipnest), test_values
                 )
 
     def test_hdf5_read_outoforder(self):
@@ -117,8 +102,8 @@ class Hdf5IoTestCase(unittest.TestCase):
         ra = np.random.random(n_rand) * 360.0
         dec = np.random.random(n_rand) * 180.0 - 90.0
 
-        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
-        fname = os.path.join(self.test_dir, 'healsparse_map_outoforder.hdf5')
+        self.test_dir = tempfile.mkdtemp(dir="./", prefix="TestHealSparse-")
+        fname = os.path.join(self.test_dir, "healsparse_map_outoforder.hdf5")
 
         sparse_map = healsparse.HealSparseMap.make_empty(
             nside_coverage, nside_map, np.float64
@@ -132,7 +117,7 @@ class Hdf5IoTestCase(unittest.TestCase):
         values2 = np.random.random(pixel2.size)
         sparse_map.update_values_pix(pixel2, values2)
 
-        sparse_map.write(fname, format='hdf5')
+        sparse_map.write(fname, format="hdf5")
 
         sparse_map2 = healsparse.HealSparseMap.read(fname)
 
@@ -142,32 +127,22 @@ class Hdf5IoTestCase(unittest.TestCase):
         test_map[pixel2] = values2
 
         testing.assert_almost_equal(
-            sparse_map2.get_values_pix(ipnest),
-            test_map[ipnest]
+            sparse_map2.get_values_pix(ipnest), test_map[ipnest]
         )
 
         if test_pixels_read:
-            sparse_map_small = healsparse.HealSparseMap.read(
-                fname,
-                pixels=[0, 1, 3179]
-            )
+            sparse_map_small = healsparse.HealSparseMap.read(fname, pixels=[0, 1, 3179])
 
-            ipnest_cov = np.right_shift(
-                ipnest,
-                sparse_map_small._cov_map.bit_shift
-            )
+            ipnest_cov = np.right_shift(ipnest, sparse_map_small._cov_map.bit_shift)
 
             test_values_small = test_map[ipnest]
-            outside_small, = np.where(
-                (ipnest_cov != 0) &
-                (ipnest_cov != 1) &
-                (ipnest_cov != 3179)
+            (outside_small,) = np.where(
+                (ipnest_cov != 0) & (ipnest_cov != 1) & (ipnest_cov != 3179)
             )
             test_values_small[outside_small] = hpg.UNSEEN
 
             testing.assert_almost_equal(
-                sparse_map_small.get_values_pix(ipnest),
-                test_values_small
+                sparse_map_small.get_values_pix(ipnest), test_values_small
             )
 
     def test_hdf5_writeread_withheader(self):
@@ -179,26 +154,24 @@ class Hdf5IoTestCase(unittest.TestCase):
         nside_coverage = 32
         nside_map = 64
 
-        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
-        fname = os.path.join(self.test_dir, 'sparsemap_with_header.hdf5')
+        self.test_dir = tempfile.mkdtemp(dir="./", prefix="TestHealSparse-")
+        fname = os.path.join(self.test_dir, "sparsemap_with_header.hdf5")
 
         full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
         full_map[0:20000] = np.random.random(size=20000)
 
         sparse_map = healsparse.HealSparseMap(
-            healpix_map=full_map,
-            nside_coverage=nside_coverage,
-            nest=True
+            healpix_map=full_map, nside_coverage=nside_coverage, nest=True
         )
 
-        hdr = {'TESTING': 1.0}
+        hdr = {"TESTING": 1.0}
         sparse_map.metadata = hdr
 
-        sparse_map.write(fname, format='hdf5')
+        sparse_map.write(fname, format="hdf5")
 
         ret_map, ret_hdr = healsparse.HealSparseMap.read(fname, header=True)
 
-        self.assertEqual(hdr['TESTING'], ret_hdr['TESTING'])
+        self.assertEqual(hdr["TESTING"], ret_hdr["TESTING"])
 
     def test_hdf5_writeread_highres(self):
         """
@@ -206,16 +179,14 @@ class Hdf5IoTestCase(unittest.TestCase):
         """
         random.seed(seed=12345)
 
-        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
-        fname = os.path.join(self.test_dir, 'healsparse_map.hdf5')
+        self.test_dir = tempfile.mkdtemp(dir="./", prefix="TestHealSparse-")
+        fname = os.path.join(self.test_dir, "healsparse_map.hdf5")
 
         nside_coverage = 32
         nside_map = 2**17
 
         sparse_map = healsparse.HealSparseMap.make_empty(
-            nside_sparse=nside_map,
-            nside_coverage=nside_coverage,
-            dtype=bool
+            nside_sparse=nside_map, nside_coverage=nside_coverage, dtype=bool
         )
 
         sparse_map[1_000_000:20_000_000] = True
@@ -223,32 +194,22 @@ class Hdf5IoTestCase(unittest.TestCase):
 
         valid_pixels = sparse_map.valid_pixels
 
-        sparse_map.write(fname, format='hdf5')
+        sparse_map.write(fname, format="hdf5")
 
         sparse_map2 = healsparse.HealSparseMap.read(fname)
 
-        testing.assert_array_equal(
-            sparse_map2.valid_pixels,
-            valid_pixels
-        )
+        testing.assert_array_equal(sparse_map2.valid_pixels, valid_pixels)
 
-        testing.assert_array_equal(
-            sparse_map2.get_values_pix(valid_pixels),
-            True
-        )
+        testing.assert_array_equal(sparse_map2.get_values_pix(valid_pixels), True)
 
         if test_pixels_read:
             for covpix_map in sparse_map.get_covpix_maps():
-                covpix, = np.where(covpix_map.coverage_mask)
+                (covpix,) = np.where(covpix_map.coverage_mask)
 
-                covpix_map2 = healsparse.HealSparseMap.read(
-                    fname,
-                    pixels=covpix
-                )
+                covpix_map2 = healsparse.HealSparseMap.read(fname, pixels=covpix)
 
                 testing.assert_array_equal(
-                    covpix_map2.valid_pixels,
-                    covpix_map.valid_pixels
+                    covpix_map2.valid_pixels, covpix_map.valid_pixels
                 )
 
     def test_hdf5_writeread_bool(self):
@@ -256,22 +217,19 @@ class Hdf5IoTestCase(unittest.TestCase):
         nside_coverage = 32
         nside_map = 64
 
-        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
-        fname = os.path.join(self.test_dir, 'healsparse_map.hdf5')
+        self.test_dir = tempfile.mkdtemp(dir="./", prefix="TestHealSparse-")
+        fname = os.path.join(self.test_dir, "healsparse_map.hdf5")
 
         sparse_map = healsparse.HealSparseMap.make_empty(
             nside_coverage, nside_map, bool
         )
         sparse_map[30000:30005] = True
 
-        sparse_map.write(fname, format='hdf5')
+        sparse_map.write(fname, format="hdf5")
 
         sparse_map2 = healsparse.HealSparseMap.read(fname)
 
-        testing.assert_array_equal(
-            sparse_map2[30000:30005],
-            True
-        )
+        testing.assert_array_equal(sparse_map2[30000:30005], True)
 
         self.assertEqual(len(sparse_map2.valid_pixels), 5)
 
@@ -283,5 +241,5 @@ class Hdf5IoTestCase(unittest.TestCase):
             shutil.rmtree(self.test_dir, True)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_io_hdf5.py
+++ b/tests/test_io_hdf5.py
@@ -130,13 +130,11 @@ class Hdf5IoTestCase(unittest.TestCase):
             sparse_map2.get_values_pix(ipnest), test_map[ipnest]
         )
 
-        #test if out of order pixel load works
-        sparse_map3 = healsparse.HealSparseMap.read(fname, pixels=[1,2,4988])
+        # test if out of order pixel load works
+        sparse_map3 = healsparse.HealSparseMap.read(fname, pixels=[1, 2, 4988])
         hp3 = sparse_map3.generate_healpix_map()
-        select = (hp3 != hpg.UNSEEN)
-        testing.assert_almost_equal(
-            hp3[select], test_map[select]
-        )
+        select = hp3 != hpg.UNSEEN
+        testing.assert_almost_equal(hp3[select], test_map[select])
 
         if test_pixels_read:
             sparse_map_small = healsparse.HealSparseMap.read(fname, pixels=[0, 1, 3179])

--- a/tests/test_io_hdf5.py
+++ b/tests/test_io_hdf5.py
@@ -131,11 +131,11 @@ class Hdf5IoTestCase(unittest.TestCase):
         )
 
         #test if out of order pixel load works
-        sparse_map3 = healsparse.HealSparseMap.read(fname, pixels=pixel)
-        test_map2 = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
-        test_map2[pixel] = values
+        sparse_map3 = healsparse.HealSparseMap.read(fname, pixels=[1,2,4988])
+        hp3 = sparse_map3.generate_healpix_map()
+        select = (hp3 != hpg.UNSEEN)
         testing.assert_almost_equal(
-            sparse_map3.get_values_pix(ipnest), test_map[ipnest]
+            hp3[select], test_map[select]
         )
 
         if test_pixels_read:

--- a/tests/test_io_hdf5.py
+++ b/tests/test_io_hdf5.py
@@ -130,6 +130,14 @@ class Hdf5IoTestCase(unittest.TestCase):
             sparse_map2.get_values_pix(ipnest), test_map[ipnest]
         )
 
+        #test if out of order pixel load works
+        sparse_map3 = healsparse.HealSparseMap.read(fname, pixels=pixel)
+        test_map2 = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
+        test_map2[pixel] = values
+        testing.assert_almost_equal(
+            sparse_map3.get_values_pix(ipnest), test_map[ipnest]
+        )
+
         if test_pixels_read:
             sparse_map_small = healsparse.HealSparseMap.read(fname, pixels=[0, 1, 3179])
 

--- a/tests/test_io_hdf5.py
+++ b/tests/test_io_hdf5.py
@@ -268,7 +268,7 @@ class Hdf5IoTestCase(unittest.TestCase):
         self.test_dir = tempfile.mkdtemp(dir="./", prefix="TestHealSparse-")
         fname = os.path.join(self.test_dir, "healsparse_map.hdf5")
 
-        dtype = [('gal_delta','f8'),('star_num','i4'),('sky_brightness','f4')]
+        dtype = [('gal_delta', 'f8'), ('star_num', 'i4'), ('sky_brightness', 'f4')]
 
         sparse_map = healsparse.HealSparseMap.make_empty(
             nside_coverage, nside_map, dtype=dtype, primary='gal_delta'
@@ -286,9 +286,15 @@ class Hdf5IoTestCase(unittest.TestCase):
 
         sparse_map2 = healsparse.HealSparseMap.read(fname)
 
-        testing.assert_array_equal(sparse_map['gal_delta'][30000:30005], sparse_map2['gal_delta'][30000:30005])
-        testing.assert_array_equal(sparse_map['star_num'][30000:30005], sparse_map2['star_num'][30000:30005])
-        testing.assert_array_equal(sparse_map['sky_brightness'][30000:30005], sparse_map2['sky_brightness'][30000:30005])
+        testing.assert_array_equal(
+            sparse_map['gal_delta'][30000:30005],
+            sparse_map2['gal_delta'][30000:30005])
+        testing.assert_array_equal(
+            sparse_map['star_num'][30000:30005],
+            sparse_map2['star_num'][30000:30005])
+        testing.assert_array_equal(
+            sparse_map['sky_brightness'][30000:30005],
+            sparse_map2['sky_brightness'][30000:30005])
 
         self.assertEqual(len(sparse_map2.valid_pixels), npop)
 

--- a/tests/test_io_hdf5.py
+++ b/tests/test_io_hdf5.py
@@ -1,0 +1,287 @@
+import unittest
+import numpy.testing as testing
+import numpy as np
+import hpgeom as hpg
+from numpy import random
+import tempfile
+import shutil
+import os
+import pathlib
+
+import healsparse
+
+#read specific coverage pixels not yet implemented
+test_pixels_read = False
+
+class Hdf5IoTestCase(unittest.TestCase):
+    def test_hdf5_writeread(self):
+        """
+        Test HDF5 i/o functionality.
+        """
+        random.seed(seed=12345)
+
+        nside_coverage = 32
+        nside_map = 64
+
+        n_rand = 1000
+        ra = np.random.random(n_rand) * 360.0
+        dec = np.random.random(n_rand) * 180.0 - 90.0
+
+        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
+
+        # Generate a random map
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
+        full_map[0:20000] = np.random.random(size=20000)
+
+        ipnest = hpg.angle_to_pixel(nside_map, ra, dec)
+        test_values = full_map[ipnest]
+
+        sparse_map = healsparse.HealSparseMap.make_empty(
+            nside_coverage,
+            nside_map,
+            full_map.dtype
+        )
+        u, = np.where(full_map > hpg.UNSEEN)
+        sparse_map[u] = full_map[u]
+
+        for mode in ("str", "path"):
+            if mode == "str":
+                fname = os.path.join(self.test_dir, "healsparse_map.hdf5")
+            else:
+                fname = pathlib.Path(self.test_dir) / "healsparse_map2.hdf5"
+
+            # Write map
+            sparse_map.write(fname, format="hdf5")
+
+            # Read full map
+            sparse_map2 = healsparse.HealSparseMap.read(fname)
+
+            testing.assert_almost_equal(
+                sparse_map2.get_values_pix(ipnest),
+                test_values
+            )
+
+            if test_pixels_read:
+            # Non-unique pixels should error
+                self.assertRaises(
+                    RuntimeError,
+                    healsparse.HealSparseMap.read,
+                    fname,
+                    pixels=[0, 0]
+                )
+
+                # Read two coverage pixels
+                sparse_map_small = healsparse.HealSparseMap.read(
+                    fname,
+                    pixels=[0, 1]
+                )
+
+                cov_mask = sparse_map_small.coverage_mask
+                self.assertEqual(cov_mask.sum(), 2)
+
+                ipnest_cov = np.right_shift(
+                    ipnest,
+                    sparse_map_small._cov_map.bit_shift
+                )
+
+                test_values2 = test_values.copy()
+                outside_small, = np.where(ipnest_cov > 1)
+                test_values2[outside_small] = hpg.UNSEEN
+
+                testing.assert_almost_equal(
+                    sparse_map_small.get_values_pix(ipnest),
+                    test_values2
+                )
+
+                # Read all coverage pixels explicitly
+                sparse_map_full = healsparse.HealSparseMap.read(
+                    fname,
+                    pixels=np.arange(hpg.nside_to_npixel(nside_coverage)),
+                )
+
+                testing.assert_almost_equal(
+                    sparse_map_full.get_values_pix(ipnest),
+                    test_values
+                )
+
+    def test_hdf5_read_outoforder(self):
+        """
+        Test reading HDF5 maps written with out-of-order pixels.
+        """
+        random.seed(seed=12345)
+
+        nside_coverage = 32
+        nside_map = 64
+
+        n_rand = 1000
+        ra = np.random.random(n_rand) * 360.0
+        dec = np.random.random(n_rand) * 180.0 - 90.0
+
+        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
+        fname = os.path.join(self.test_dir, 'healsparse_map_outoforder.hdf5')
+
+        sparse_map = healsparse.HealSparseMap.make_empty(
+            nside_coverage, nside_map, np.float64
+        )
+
+        pixel = np.arange(4000, 20000)
+        values = np.random.random(pixel.size)
+        sparse_map.update_values_pix(pixel, values)
+
+        pixel2 = np.arange(1000)
+        values2 = np.random.random(pixel2.size)
+        sparse_map.update_values_pix(pixel2, values2)
+
+        sparse_map.write(fname, format='hdf5')
+
+        sparse_map2 = healsparse.HealSparseMap.read(fname)
+
+        ipnest = hpg.angle_to_pixel(nside_map, ra, dec)
+        test_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
+        test_map[pixel] = values
+        test_map[pixel2] = values2
+
+        testing.assert_almost_equal(
+            sparse_map2.get_values_pix(ipnest),
+            test_map[ipnest]
+        )
+
+        if test_pixels_read:
+            sparse_map_small = healsparse.HealSparseMap.read(
+                fname,
+                pixels=[0, 1, 3179]
+            )
+
+            ipnest_cov = np.right_shift(
+                ipnest,
+                sparse_map_small._cov_map.bit_shift
+            )
+
+            test_values_small = test_map[ipnest]
+            outside_small, = np.where(
+                (ipnest_cov != 0) &
+                (ipnest_cov != 1) &
+                (ipnest_cov != 3179)
+            )
+            test_values_small[outside_small] = hpg.UNSEEN
+
+            testing.assert_almost_equal(
+                sparse_map_small.get_values_pix(ipnest),
+                test_values_small
+            )
+
+    def test_hdf5_writeread_withheader(self):
+        """
+        Test HDF5 i/o functionality with metadata.
+        """
+        random.seed(seed=12345)
+
+        nside_coverage = 32
+        nside_map = 64
+
+        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
+        fname = os.path.join(self.test_dir, 'sparsemap_with_header.hdf5')
+
+        full_map = np.zeros(hpg.nside_to_npixel(nside_map)) + hpg.UNSEEN
+        full_map[0:20000] = np.random.random(size=20000)
+
+        sparse_map = healsparse.HealSparseMap(
+            healpix_map=full_map,
+            nside_coverage=nside_coverage,
+            nest=True
+        )
+
+        hdr = {'TESTING': 1.0}
+        sparse_map.metadata = hdr
+
+        sparse_map.write(fname, format='hdf5')
+
+        ret_map, ret_hdr = healsparse.HealSparseMap.read(fname, header=True)
+
+        self.assertEqual(hdr['TESTING'], ret_hdr['TESTING'])
+
+    def test_hdf5_writeread_highres(self):
+        """
+        Test HDF5 i/o functionality at very high resolution.
+        """
+        random.seed(seed=12345)
+
+        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
+        fname = os.path.join(self.test_dir, 'healsparse_map.hdf5')
+
+        nside_coverage = 32
+        nside_map = 2**17
+
+        sparse_map = healsparse.HealSparseMap.make_empty(
+            nside_sparse=nside_map,
+            nside_coverage=nside_coverage,
+            dtype=bool
+        )
+
+        sparse_map[1_000_000:20_000_000] = True
+        sparse_map[1_700_000_000:1_720_000_000] = True
+
+        valid_pixels = sparse_map.valid_pixels
+
+        sparse_map.write(fname, format='hdf5')
+
+        sparse_map2 = healsparse.HealSparseMap.read(fname)
+
+        testing.assert_array_equal(
+            sparse_map2.valid_pixels,
+            valid_pixels
+        )
+
+        testing.assert_array_equal(
+            sparse_map2.get_values_pix(valid_pixels),
+            True
+        )
+
+        if test_pixels_read:
+            for covpix_map in sparse_map.get_covpix_maps():
+                covpix, = np.where(covpix_map.coverage_mask)
+
+                covpix_map2 = healsparse.HealSparseMap.read(
+                    fname,
+                    pixels=covpix
+                )
+
+                testing.assert_array_equal(
+                    covpix_map2.valid_pixels,
+                    covpix_map.valid_pixels
+                )
+
+    def test_hdf5_writeread_bool(self):
+        """Test writing and reading a bool map."""
+        nside_coverage = 32
+        nside_map = 64
+
+        self.test_dir = tempfile.mkdtemp(dir='./', prefix='TestHealSparse-')
+        fname = os.path.join(self.test_dir, 'healsparse_map.hdf5')
+
+        sparse_map = healsparse.HealSparseMap.make_empty(
+            nside_coverage, nside_map, bool
+        )
+        sparse_map[30000:30005] = True
+
+        sparse_map.write(fname, format='hdf5')
+
+        sparse_map2 = healsparse.HealSparseMap.read(fname)
+
+        testing.assert_array_equal(
+            sparse_map2[30000:30005],
+            True
+        )
+
+        self.assertEqual(len(sparse_map2.valid_pixels), 5)
+
+    def setUp(self):
+        self.test_dir = None
+
+    def tearDown(self):
+        if self.test_dir is not None and os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir, True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_io_hdf5.py
+++ b/tests/test_io_hdf5.py
@@ -10,9 +10,6 @@ import pathlib
 
 import healsparse
 
-# read specific coverage pixels not yet implemented
-test_pixels_read = False
-
 
 class Hdf5IoTestCase(unittest.TestCase):
     def test_hdf5_writeread(self):
@@ -57,37 +54,36 @@ class Hdf5IoTestCase(unittest.TestCase):
 
             testing.assert_almost_equal(sparse_map2.get_values_pix(ipnest), test_values)
 
-            if test_pixels_read:
-                # Non-unique pixels should error
-                self.assertRaises(
-                    RuntimeError, healsparse.HealSparseMap.read, fname, pixels=[0, 0]
-                )
+            # Non-unique pixels should error
+            self.assertRaises(
+                RuntimeError, healsparse.HealSparseMap.read, fname, pixels=[0, 0]
+            )
 
-                # Read two coverage pixels
-                sparse_map_small = healsparse.HealSparseMap.read(fname, pixels=[0, 1])
+            # Read two coverage pixels
+            sparse_map_small = healsparse.HealSparseMap.read(fname, pixels=[0, 1])
 
-                cov_mask = sparse_map_small.coverage_mask
-                self.assertEqual(cov_mask.sum(), 2)
+            cov_mask = sparse_map_small.coverage_mask
+            self.assertEqual(cov_mask.sum(), 2)
 
-                ipnest_cov = np.right_shift(ipnest, sparse_map_small._cov_map.bit_shift)
+            ipnest_cov = np.right_shift(ipnest, sparse_map_small._cov_map.bit_shift)
 
-                test_values2 = test_values.copy()
-                (outside_small,) = np.where(ipnest_cov > 1)
-                test_values2[outside_small] = hpg.UNSEEN
+            test_values2 = test_values.copy()
+            (outside_small,) = np.where(ipnest_cov > 1)
+            test_values2[outside_small] = hpg.UNSEEN
 
-                testing.assert_almost_equal(
-                    sparse_map_small.get_values_pix(ipnest), test_values2
-                )
+            testing.assert_almost_equal(
+                sparse_map_small.get_values_pix(ipnest), test_values2
+            )
 
-                # Read all coverage pixels explicitly
-                sparse_map_full = healsparse.HealSparseMap.read(
-                    fname,
-                    pixels=np.arange(hpg.nside_to_npixel(nside_coverage)),
-                )
+            # Read all coverage pixels explicitly
+            sparse_map_full = healsparse.HealSparseMap.read(
+                fname,
+                pixels=np.arange(hpg.nside_to_npixel(nside_coverage)),
+            )
 
-                testing.assert_almost_equal(
-                    sparse_map_full.get_values_pix(ipnest), test_values
-                )
+            testing.assert_almost_equal(
+                sparse_map_full.get_values_pix(ipnest), test_values
+            )
 
     def test_hdf5_read_outoforder(self):
         """
@@ -136,20 +132,19 @@ class Hdf5IoTestCase(unittest.TestCase):
         select = hp3 != hpg.UNSEEN
         testing.assert_almost_equal(hp3[select], test_map[select])
 
-        if test_pixels_read:
-            sparse_map_small = healsparse.HealSparseMap.read(fname, pixels=[0, 1, 3179])
+        sparse_map_small = healsparse.HealSparseMap.read(fname, pixels=[0, 1, 3179])
 
-            ipnest_cov = np.right_shift(ipnest, sparse_map_small._cov_map.bit_shift)
+        ipnest_cov = np.right_shift(ipnest, sparse_map_small._cov_map.bit_shift)
 
-            test_values_small = test_map[ipnest]
-            (outside_small,) = np.where(
-                (ipnest_cov != 0) & (ipnest_cov != 1) & (ipnest_cov != 3179)
-            )
-            test_values_small[outside_small] = hpg.UNSEEN
+        test_values_small = test_map[ipnest]
+        (outside_small,) = np.where(
+            (ipnest_cov != 0) & (ipnest_cov != 1) & (ipnest_cov != 3179)
+        )
+        test_values_small[outside_small] = hpg.UNSEEN
 
-            testing.assert_almost_equal(
-                sparse_map_small.get_values_pix(ipnest), test_values_small
-            )
+        testing.assert_almost_equal(
+            sparse_map_small.get_values_pix(ipnest), test_values_small
+        )
 
     def test_hdf5_writeread_withheader(self):
         """
@@ -208,15 +203,14 @@ class Hdf5IoTestCase(unittest.TestCase):
 
         testing.assert_array_equal(sparse_map2.get_values_pix(valid_pixels), True)
 
-        if test_pixels_read:
-            for covpix_map in sparse_map.get_covpix_maps():
-                (covpix,) = np.where(covpix_map.coverage_mask)
+        for covpix_map in sparse_map.get_covpix_maps():
+            (covpix,) = np.where(covpix_map.coverage_mask)
 
-                covpix_map2 = healsparse.HealSparseMap.read(fname, pixels=covpix)
+            covpix_map2 = healsparse.HealSparseMap.read(fname, pixels=covpix)
 
-                testing.assert_array_equal(
-                    covpix_map2.valid_pixels, covpix_map.valid_pixels
-                )
+            testing.assert_array_equal(
+                covpix_map2.valid_pixels, covpix_map.valid_pixels
+            )
 
     def test_hdf5_writeread_bool(self):
         """Test writing and reading a bool map."""

--- a/tests/test_io_hdf5.py
+++ b/tests/test_io_hdf5.py
@@ -239,6 +239,59 @@ class Hdf5IoTestCase(unittest.TestCase):
 
         self.assertEqual(len(sparse_map2.valid_pixels), 5)
 
+    def test_hdf5_writeread_bool_bitpacked(self):
+        """Test writing and reading a bool map."""
+        nside_coverage = 32
+        nside_map = 128
+
+        self.test_dir = tempfile.mkdtemp(dir="./", prefix="TestHealSparse-")
+        fname = os.path.join(self.test_dir, "healsparse_map.hdf5")
+
+        sparse_map = healsparse.HealSparseMap.make_empty(
+            nside_coverage, nside_map, bool, bit_packed=True
+        )
+        sparse_map[30000:30005] = True
+
+        sparse_map.write(fname, format="hdf5")
+
+        sparse_map2 = healsparse.HealSparseMap.read(fname)
+
+        testing.assert_array_equal(sparse_map2[30000:30005], True)
+
+        self.assertEqual(len(sparse_map2.valid_pixels), 5)
+
+    def test_hdf5_writeread_rec(self):
+        """Test writing and reading a recarray map."""
+        nside_coverage = 32
+        nside_map = 64
+
+        self.test_dir = tempfile.mkdtemp(dir="./", prefix="TestHealSparse-")
+        fname = os.path.join(self.test_dir, "healsparse_map.hdf5")
+
+        dtype = [('gal_delta','f8'),('star_num','i4'),('sky_brightness','f4')]
+
+        sparse_map = healsparse.HealSparseMap.make_empty(
+            nside_coverage, nside_map, dtype=dtype, primary='gal_delta'
+        )
+
+        npop = 5
+        pixels = np.arange(30000, 30000+npop)
+        pix_vals = np.zeros(npop, dtype=dtype)
+        pix_vals['gal_delta'] = -1 + 10*np.random.random(npop)
+        pix_vals['star_num'] = np.random.randint(low=0, high=10, size=npop)
+        pix_vals['sky_brightness'] = 3000 + 10000*np.random.random(size=npop)
+        sparse_map.update_values_pix(pixels, pix_vals)
+
+        sparse_map.write(fname, format="hdf5")
+
+        sparse_map2 = healsparse.HealSparseMap.read(fname)
+
+        testing.assert_array_equal(sparse_map['gal_delta'][30000:30005], sparse_map2['gal_delta'][30000:30005])
+        testing.assert_array_equal(sparse_map['star_num'][30000:30005], sparse_map2['star_num'][30000:30005])
+        testing.assert_array_equal(sparse_map['sky_brightness'][30000:30005], sparse_map2['sky_brightness'][30000:30005])
+
+        self.assertEqual(len(sparse_map2.valid_pixels), npop)
+
     def setUp(self):
         self.test_dir = None
 


### PR DESCRIPTION
Added read/write to a group in an hdf5 file

Useful for saving maps in TXPipe/ceci where we want N maps with different masks saved to the same file (e.g. galaxy density maps in different tomo bins)

Currently it only allows the whole map to the read (cannot specify list of coverage pixels with `pixels`) but this can be added