### PR TITLE
Inequality operators

### DIFF
--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -39,6 +39,37 @@ Arithmetic operations with a constant are very simple, and are handled with the 
     print(map_float2[0: 10000])
     >>> [100. 100. 100. ... 100. 100. 100.]
 
+    map_float3 = map_float > 0.0
+    print(map_float3[0: 10000])
+    >>> [False False False ... False False False]
+
+Comparison operations with a constant are also handled with the default Python operations. 
+The equality and inequality operations can be applied against a constant (returning a boolean healsparse map) 
+or another healsparse (returning a boolean)
+
+.. code-block :: python
+
+    import numpy as np
+    import healsparse
+
+    map_float = healsparse.HealSparseMap.make_empty(32, 4096, np.float64)
+    map_float[0: 10000] = np.random.choice([0.5, 1.0, 1.5], size=10000)
+
+    print(map_float[0: 10000])
+    >>> [1.  0.5 1.  ... 1.5 1.  0.5]
+
+    map_float2 = map_float > 1.1
+    print(map_float2[0: 10000])
+    >>> [False False False ...  True False False]
+
+    map_float2 = map_float == 1.0
+    print(map_float2[0: 10000])
+    >>> [ True False  True ... False  True False]
+
+    map_float == map_float.copy()
+    >>> True
+    
+
 
 Operations With Multiple Maps
 -----------------------------

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -16,7 +16,6 @@ class HealSparseMap(object):
     """
     Class to define a HealSparseMap
     """
-
     def __init__(self, cov_map=None, cov_index_map=None, sparse_map=None, nside_sparse=None,
                  healpix_map=None, nside_coverage=None, primary=None, sentinel=None,
                  nest=True, metadata=None, _is_view=False):
@@ -2216,6 +2215,42 @@ class HealSparseMap(object):
 
         return self._apply_operation(other, np.power, in_place=True)
 
+    def __lt__(self, other):
+        """
+        Apply less than operator to a map with a constant
+
+        Returns boolean map
+        """
+
+        return self._apply_operation(other, np.less, sentinel=False).as_bit_packed_map()
+
+    def __le__(self, other):
+        """
+        Apply less than or equal to operator to a map with a constant
+
+        Returns boolean map
+        """
+
+        return self._apply_operation(other, np.less_equal, sentinel=False).as_bit_packed_map()
+    
+    def __gt__(self, other):
+        """
+        Apply greater than operator to a map with a constant
+
+        Returns boolean map
+        """
+
+        return self._apply_operation(other, np.greater, sentinel=False).as_bit_packed_map()
+
+    def __ge__(self, other):
+        """
+        Apply greater than or equal to operator to a map with a constant
+
+        Returns boolean map
+        """
+
+        return self._apply_operation(other, np.greater_equal, sentinel=False).as_bit_packed_map()
+    
     def __and__(self, other):
         """
         Perform a bitwise and with a constant.

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -16,6 +16,7 @@ class HealSparseMap(object):
     """
     Class to define a HealSparseMap
     """
+
     def __init__(self, cov_map=None, cov_index_map=None, sparse_map=None, nside_sparse=None,
                  healpix_map=None, nside_coverage=None, primary=None, sentinel=None,
                  nest=True, metadata=None, _is_view=False):
@@ -2232,7 +2233,7 @@ class HealSparseMap(object):
         """
 
         return self._apply_operation(other, np.less_equal, sentinel=False).as_bit_packed_map()
-    
+
     def __gt__(self, other):
         """
         Apply greater than operator to a map with a constant
@@ -2260,7 +2261,7 @@ class HealSparseMap(object):
         if isinstance(other, HealSparseMap):
             # fall back to standard __eq__ if other is a map
             return NotImplemented
-        
+
         return self._apply_operation(other, np.equal, sentinel=False).as_bit_packed_map()
 
     def __ne__(self, other):
@@ -2274,7 +2275,7 @@ class HealSparseMap(object):
             return NotImplemented
 
         return self._apply_operation(other, np.not_equal, sentinel=False).as_bit_packed_map()
-    
+
     __hash__ = object.__hash__
 
     def __and__(self, other):
@@ -2511,7 +2512,7 @@ class HealSparseMap(object):
         else:
             output_sentinel = self._sentinel if sentinel is None else sentinel
             if sentinel is None:
-                #compute func in-place
+                # Compute func in-place
                 combinedSparseMap = self._sparse_map.copy()
                 if self._is_wide_mask:
                     for i in range(self._wide_mask_width):
@@ -2520,7 +2521,7 @@ class HealSparseMap(object):
                 else:
                     func(combinedSparseMap, other, out=combinedSparseMap, where=valid_sparse_pixels)
             else:
-                #make empty combinedSparseMap with sentinel dtype and fill
+                # Make empty combinedSparseMap with sentinel dtype and fill
                 combinedSparseMap = np.full_like(self._sparse_map, fill_value=sentinel, dtype=type(sentinel))
                 if self._is_wide_mask:
                     for i in range(self._wide_mask_width):

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -2358,7 +2358,7 @@ class HealSparseMap(object):
             sentinel=self._sentinel,
         )
 
-    def _apply_operation(self, other, func, int_only=False, in_place=False):
+    def _apply_operation(self, other, func, int_only=False, in_place=False, sentinel=None):
         """
         Apply a generic arithmetic function.
 
@@ -2374,6 +2374,9 @@ class HealSparseMap(object):
             Only accept integer types.
         in_place : `bool`, optional
             Perform operation in-place.
+        sentinel : None, `int` or `float`
+            sentinel value for the output map, if None will use the same value as self
+            must be None if in_place is True
 
         Returns
         -------
@@ -2436,6 +2439,7 @@ class HealSparseMap(object):
             valid_sparse_pixels = (self._sparse_map != self._sentinel)
 
         if in_place:
+            assert sentinel is None
             if self._is_wide_mask:
                 for i in range(self._wide_mask_width):
                     col = self._sparse_map[:, i]
@@ -2444,6 +2448,7 @@ class HealSparseMap(object):
                 func(self._sparse_map, other, out=self._sparse_map, where=valid_sparse_pixels)
             return self
         else:
+            output_sentinel = self._sentinel if sentinel is None else sentinel
             combinedSparseMap = self._sparse_map.copy()
             if self._is_wide_mask:
                 for i in range(self._wide_mask_width):
@@ -2452,7 +2457,7 @@ class HealSparseMap(object):
             else:
                 func(combinedSparseMap, other, out=combinedSparseMap, where=valid_sparse_pixels)
             return HealSparseMap(cov_map=self._cov_map, sparse_map=combinedSparseMap,
-                                 nside_sparse=self._nside_sparse, sentinel=self._sentinel)
+                                 nside_sparse=self._nside_sparse, sentinel=output_sentinel)
 
     def _apply_boolean_map_operation(self, other, name, in_place=False):
         """Apply an operation to a boolean mask map.

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -2449,13 +2449,25 @@ class HealSparseMap(object):
             return self
         else:
             output_sentinel = self._sentinel if sentinel is None else sentinel
-            combinedSparseMap = self._sparse_map.copy()
-            if self._is_wide_mask:
-                for i in range(self._wide_mask_width):
-                    col = combinedSparseMap[:, i]
-                    func(col, other_value[i], out=col, where=valid_sparse_pixels)
+            if sentinel is None:
+                #compute func in-place
+                combinedSparseMap = self._sparse_map.copy()
+                if self._is_wide_mask:
+                    for i in range(self._wide_mask_width):
+                        col = combinedSparseMap[:, i]
+                        func(col, other_value[i], out=col, where=valid_sparse_pixels)
+                else:
+                    func(combinedSparseMap, other, out=combinedSparseMap, where=valid_sparse_pixels)
             else:
-                func(combinedSparseMap, other, out=combinedSparseMap, where=valid_sparse_pixels)
+                #make empty combinedSparseMap with sentinel dtype and fill
+                combinedSparseMap = np.full_like(self._sparse_map, fill_value=sentinel, dtype=type(sentinel))
+                if self._is_wide_mask:
+                    for i in range(self._wide_mask_width):
+                        in_col = self._sparse_map[:, i]
+                        out_col = combinedSparseMap[:, i]
+                        func(in_col, other_value[i], out=out_col, where=valid_sparse_pixels)
+                else:
+                    func(self._sparse_map, other, out=combinedSparseMap, where=valid_sparse_pixels)
             return HealSparseMap(cov_map=self._cov_map, sparse_map=combinedSparseMap,
                                  nside_sparse=self._nside_sparse, sentinel=output_sentinel)
 

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -2250,7 +2250,33 @@ class HealSparseMap(object):
         """
 
         return self._apply_operation(other, np.greater_equal, sentinel=False).as_bit_packed_map()
+
+    def __eq__(self, other):
+        """
+        Apply equal to operator to a map with a constant
+
+        Returns boolean map
+        """
+        if isinstance(other, HealSparseMap):
+            # fall back to standard __eq__ if other is a map
+            return NotImplemented
+        
+        return self._apply_operation(other, np.equal, sentinel=False).as_bit_packed_map()
+
+    def __ne__(self, other):
+        """
+        Apply not equal to operator to a map with a constant
+
+        Returns boolean map
+        """
+        if isinstance(other, HealSparseMap):
+            # fall back to standard __eq__ if other is a map
+            return NotImplemented
+
+        return self._apply_operation(other, np.not_equal, sentinel=False).as_bit_packed_map()
     
+    __hash__ = object.__hash__
+
     def __and__(self, other):
         """
         Perform a bitwise and with a constant.

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -2254,25 +2254,37 @@ class HealSparseMap(object):
 
     def __eq__(self, other):
         """
-        Apply equal to operator to a map with a constant
+        Apply equal to operator to a map
+        
+        If other is a HealSparseMap, return True if the maps are equal.
 
-        Returns boolean map
+        Otherwise apply equality against a constant and return a boolean map.
         """
         if isinstance(other, HealSparseMap):
-            # fall back to standard __eq__ if other is a map
-            return NotImplemented
+            if self._nside_sparse != other._nside_sparse:
+                return False
+            if self._cov_map.nside_coverage != other._cov_map.nside_coverage:
+                return False
+            if self._sentinel != other._sentinel:
+                return False
+            if not np.array_equal(self._cov_map.coverage_mask, other._cov_map.coverage_mask):
+                return False
+            if not np.array_equal(self._sparse_map, other._sparse_map):
+                return False
+            return True
 
         return self._apply_operation(other, np.equal, sentinel=False)
 
     def __ne__(self, other):
         """
-        Apply not equal to operator to a map with a constant
+        Apply not equal to operator to a map
+        
+        If other is a HealSparseMap, return True if the maps are not equal.
 
-        Returns boolean map
+        Otherwise apply inequality against a constant and return a boolean map.
         """
         if isinstance(other, HealSparseMap):
-            # fall back to standard __eq__ if other is a map
-            return NotImplemented
+            return not self.__eq__(other)
 
         return self._apply_operation(other, np.not_equal, sentinel=False)
 

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -2276,8 +2276,6 @@ class HealSparseMap(object):
 
         return self._apply_operation(other, np.not_equal, sentinel=False)
 
-    __hash__ = object.__hash__
-
     def __and__(self, other):
         """
         Perform a bitwise and with a constant.

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -2255,7 +2255,7 @@ class HealSparseMap(object):
     def __eq__(self, other):
         """
         Apply equal to operator to a map
-        
+
         If other is a HealSparseMap, return True if the maps are equal.
 
         Otherwise apply equality against a constant and return a boolean map.
@@ -2278,7 +2278,7 @@ class HealSparseMap(object):
     def __ne__(self, other):
         """
         Apply not equal to operator to a map
-        
+
         If other is a HealSparseMap, return True if the maps are not equal.
 
         Otherwise apply inequality against a constant and return a boolean map.

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -2446,7 +2446,7 @@ class HealSparseMap(object):
             Only accept integer types.
         in_place : `bool`, optional
             Perform operation in-place.
-        sentinel : None, `int` or `float`
+        sentinel : None, `int`, `float` or `bool`
             sentinel value for the output map, if None will use the same value as self
             must be None if in_place is True
 

--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -2223,7 +2223,7 @@ class HealSparseMap(object):
         Returns boolean map
         """
 
-        return self._apply_operation(other, np.less, sentinel=False).as_bit_packed_map()
+        return self._apply_operation(other, np.less, sentinel=False)
 
     def __le__(self, other):
         """
@@ -2232,7 +2232,7 @@ class HealSparseMap(object):
         Returns boolean map
         """
 
-        return self._apply_operation(other, np.less_equal, sentinel=False).as_bit_packed_map()
+        return self._apply_operation(other, np.less_equal, sentinel=False)
 
     def __gt__(self, other):
         """
@@ -2241,7 +2241,7 @@ class HealSparseMap(object):
         Returns boolean map
         """
 
-        return self._apply_operation(other, np.greater, sentinel=False).as_bit_packed_map()
+        return self._apply_operation(other, np.greater, sentinel=False)
 
     def __ge__(self, other):
         """
@@ -2250,7 +2250,7 @@ class HealSparseMap(object):
         Returns boolean map
         """
 
-        return self._apply_operation(other, np.greater_equal, sentinel=False).as_bit_packed_map()
+        return self._apply_operation(other, np.greater_equal, sentinel=False)
 
     def __eq__(self, other):
         """
@@ -2262,7 +2262,7 @@ class HealSparseMap(object):
             # fall back to standard __eq__ if other is a map
             return NotImplemented
 
-        return self._apply_operation(other, np.equal, sentinel=False).as_bit_packed_map()
+        return self._apply_operation(other, np.equal, sentinel=False)
 
     def __ne__(self, other):
         """
@@ -2274,7 +2274,7 @@ class HealSparseMap(object):
             # fall back to standard __eq__ if other is a map
             return NotImplemented
 
-        return self._apply_operation(other, np.not_equal, sentinel=False).as_bit_packed_map()
+        return self._apply_operation(other, np.not_equal, sentinel=False)
 
     __hash__ = object.__hash__
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1173,7 +1173,109 @@ class OperationsTestCase(unittest.TestCase):
         hpmap_add = np.add(hpmap_add, hpmap3)
         hpmap_add[mask2] = hpg.UNSEEN
         testing.assert_almost_equal(hpmap_add, add_map.generate_healpix_map())
+    
+    def test_comparison_operators(self):
+        """
+        Test comparison operators with constants and map equality.
+        """
+        random.seed(seed=12345)
 
+        nside_coverage = 32
+        nside_map = 64
+
+        sparse_map1 = healsparse.HealSparseMap.make_empty(
+            nside_coverage,
+            nside_map,
+            np.float64
+        )
+
+        pixel1 = np.arange(4000, 20000)
+        pixel1 = np.delete(pixel1, 15000)
+        values1 = np.random.random(size=pixel1.size)
+        sparse_map1.update_values_pix(pixel1, values1)
+        hpmap1 = sparse_map1.generate_healpix_map()
+        npix = hpg.nside_to_npixel(sparse_map1.nside_sparse)
+
+        ##### >
+
+        test_map = sparse_map1 > 0.5
+        hpmap_test = np.zeros_like(hpmap1, dtype=np.bool_)
+        gd, = np.where(hpmap1 > hpg.UNSEEN)
+        hpmap_test[gd] = hpmap1[gd] > 0.5
+        testing.assert_equal(hpmap_test,
+                             test_map.get_values_pix(np.arange(npix)))
+
+        ##### >=
+
+        test_map = sparse_map1 >= 0.5
+        hpmap_test = np.zeros_like(hpmap1, dtype=np.bool_)
+        gd, = np.where(hpmap1 > hpg.UNSEEN)
+        hpmap_test[gd] = hpmap1[gd] >= 0.5
+        testing.assert_equal(hpmap_test,
+                             test_map.get_values_pix(np.arange(npix)))
+
+        ##### <
+
+        test_map = sparse_map1 < 0.5
+        hpmap_test = np.zeros_like(hpmap1, dtype=np.bool_)
+        gd, = np.where(hpmap1 > hpg.UNSEEN)
+        hpmap_test[gd] = hpmap1[gd] < 0.5
+        testing.assert_equal(hpmap_test,
+                             test_map.get_values_pix(np.arange(npix)))
+
+        ##### <=
+
+        test_map = sparse_map1 <= 0.5
+        hpmap_test = np.zeros_like(hpmap1, dtype=np.bool_)
+        gd, = np.where(hpmap1 > hpg.UNSEEN)
+        hpmap_test[gd] = hpmap1[gd] <= 0.5
+        testing.assert_equal(hpmap_test,
+                             test_map.get_values_pix(np.arange(npix)))
+
+        ##### == with constant
+
+        compare_value = values1[100]
+        test_map = sparse_map1 == compare_value
+        hpmap_test = np.zeros_like(hpmap1, dtype=np.bool_)
+        gd, = np.where(hpmap1 > hpg.UNSEEN)
+        hpmap_test[gd] = hpmap1[gd] == compare_value
+        testing.assert_equal(hpmap_test,
+                             test_map.get_values_pix(np.arange(npix)))
+
+        ##### != with constant
+
+        test_map = sparse_map1 != compare_value
+        hpmap_test = np.zeros_like(hpmap1, dtype=np.bool_)
+        gd, = np.where(hpmap1 > hpg.UNSEEN)
+        hpmap_test[gd] = hpmap1[gd] != compare_value
+        testing.assert_equal(hpmap_test,
+                             test_map.get_values_pix(np.arange(npix)))
+
+        ##### == map-map equality
+
+        sparse_map2 = sparse_map1.copy()
+
+        self.assertTrue(sparse_map1 == sparse_map2)
+        self.assertFalse(sparse_map1 != sparse_map2)
+
+        ##### != map-map inequality
+        sparse_map2.update_values_pix(
+            np.array([pixel1[0]]),
+            np.array([values1[0] + 1.0])
+        )
+        self.assertFalse(sparse_map1 == sparse_map2)
+        self.assertTrue(sparse_map1 != sparse_map2)
+
+        ##### unequal metadata
+
+        sparse_map3 = healsparse.HealSparseMap.make_empty(
+            nside_coverage,
+            nside_map * 2,
+            np.float64
+        )
+
+        self.assertFalse(sparse_map1 == sparse_map3)
+        self.assertTrue(sparse_map1 != sparse_map3)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1173,7 +1173,7 @@ class OperationsTestCase(unittest.TestCase):
         hpmap_add = np.add(hpmap_add, hpmap3)
         hpmap_add[mask2] = hpg.UNSEEN
         testing.assert_almost_equal(hpmap_add, add_map.generate_healpix_map())
-    
+
     def test_comparison_operators(self):
         """
         Test comparison operators with constants and map equality.
@@ -1196,7 +1196,7 @@ class OperationsTestCase(unittest.TestCase):
         hpmap1 = sparse_map1.generate_healpix_map()
         npix = hpg.nside_to_npixel(sparse_map1.nside_sparse)
 
-        ##### >
+        # >
 
         test_map = sparse_map1 > 0.5
         hpmap_test = np.zeros_like(hpmap1, dtype=np.bool_)
@@ -1205,7 +1205,7 @@ class OperationsTestCase(unittest.TestCase):
         testing.assert_equal(hpmap_test,
                              test_map.get_values_pix(np.arange(npix)))
 
-        ##### >=
+        # >=
 
         test_map = sparse_map1 >= 0.5
         hpmap_test = np.zeros_like(hpmap1, dtype=np.bool_)
@@ -1214,7 +1214,7 @@ class OperationsTestCase(unittest.TestCase):
         testing.assert_equal(hpmap_test,
                              test_map.get_values_pix(np.arange(npix)))
 
-        ##### <
+        # <
 
         test_map = sparse_map1 < 0.5
         hpmap_test = np.zeros_like(hpmap1, dtype=np.bool_)
@@ -1223,7 +1223,7 @@ class OperationsTestCase(unittest.TestCase):
         testing.assert_equal(hpmap_test,
                              test_map.get_values_pix(np.arange(npix)))
 
-        ##### <=
+        # <=
 
         test_map = sparse_map1 <= 0.5
         hpmap_test = np.zeros_like(hpmap1, dtype=np.bool_)
@@ -1232,7 +1232,7 @@ class OperationsTestCase(unittest.TestCase):
         testing.assert_equal(hpmap_test,
                              test_map.get_values_pix(np.arange(npix)))
 
-        ##### == with constant
+        # == with constant
 
         compare_value = values1[100]
         test_map = sparse_map1 == compare_value
@@ -1242,7 +1242,7 @@ class OperationsTestCase(unittest.TestCase):
         testing.assert_equal(hpmap_test,
                              test_map.get_values_pix(np.arange(npix)))
 
-        ##### != with constant
+        # != with constant
 
         test_map = sparse_map1 != compare_value
         hpmap_test = np.zeros_like(hpmap1, dtype=np.bool_)
@@ -1251,14 +1251,14 @@ class OperationsTestCase(unittest.TestCase):
         testing.assert_equal(hpmap_test,
                              test_map.get_values_pix(np.arange(npix)))
 
-        ##### == map-map equality
+        # == map-map equality
 
         sparse_map2 = sparse_map1.copy()
 
         self.assertTrue(sparse_map1 == sparse_map2)
         self.assertFalse(sparse_map1 != sparse_map2)
 
-        ##### != map-map inequality
+        # != map-map inequality
         sparse_map2.update_values_pix(
             np.array([pixel1[0]]),
             np.array([values1[0] + 1.0])
@@ -1266,7 +1266,7 @@ class OperationsTestCase(unittest.TestCase):
         self.assertFalse(sparse_map1 == sparse_map2)
         self.assertTrue(sparse_map1 != sparse_map2)
 
-        ##### unequal metadata
+        # unequal metadata
 
         sparse_map3 = healsparse.HealSparseMap.make_empty(
             nside_coverage,
@@ -1276,6 +1276,7 @@ class OperationsTestCase(unittest.TestCase):
 
         self.assertFalse(sparse_map1 == sparse_map3)
         self.assertTrue(sparse_map1 != sparse_map3)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Added overloads of operators < <= > >= == and !=
- The == operator will revert to default behaviour if you try `hsp_map == hsp_map` and requires explicitly redefining the base object hash. I'm happy to modify or revert this one if there are any dangers in doing this
EDIT: we now dont re-define the hash and i've implemented the eq operator for map-map comparisons


