### PR TITLE
Fix index error when computing coverage_map and fracdet from maps with out-of-order coverage pixels

### DIFF
--- a/healsparse/healSparseMap.py
+++ b/healsparse/healSparseMap.py
@@ -1011,32 +1011,9 @@ class HealSparseMap(object):
            Float array of fractional coverage of each pixel
         """
 
-        cov_map = np.zeros_like(self.coverage_mask, dtype=np.float64)
-        cov_mask = self.coverage_mask
-        npop_pix = np.count_nonzero(cov_mask)
-        if self._is_wide_mask:
-            shape_new = (npop_pix + 1,
-                         self._cov_map.nfine_per_cov,
-                         self._wide_mask_width)
-            sp_map_t = self._sparse_map.reshape(shape_new)
-            # This trickery first checks all the bits, and then sums into the
-            # coverage pixel
-            counts = np.sum(np.any(sp_map_t != self._sentinel, axis=2), axis=1)
-        elif self._is_bit_packed:
-            shape_new = (npop_pix + 1,
-                         self._cov_map.nfine_per_cov)
-            counts = self._sparse_map.sum(shape=shape_new, axis=1).astype(np.float64)
-        else:
-            shape_new = (npop_pix + 1,
-                         self._cov_map.nfine_per_cov)
-            if self._is_rec_array:
-                sp_map_t = self._sparse_map[self._primary].reshape(shape_new)
-            else:
-                sp_map_t = self._sparse_map.reshape(shape_new)
-            counts = np.sum((sp_map_t != self._sentinel), axis=1).astype(np.float64)
+        fracdet = self.fracdet_map(self.nside_coverage)
 
-        cov_map[cov_mask] = counts[1:]/self._cov_map.nfine_per_cov
-        return cov_map
+        return fracdet[:]
 
     @property
     def coverage_mask(self):
@@ -1080,8 +1057,9 @@ class HealSparseMap(object):
 
         # This code is essentially a unification of coverage_map() and degrade()
         # to get the fracdet_coverage in a single step
-        cov_mask = self.coverage_mask
-        npop_pix = np.count_nonzero(cov_mask)
+        # We need the ordered list of coverage blocks in memory.
+        coverage_pixels_ordered = self._cov_map._block_to_cov_index
+        npop_pix = len(coverage_pixels_ordered)
 
         bit_shift = _compute_bitshift(nside, self.nside_sparse)
         nfine_per_frac = 2**bit_shift
@@ -1107,9 +1085,11 @@ class HealSparseMap(object):
 
         fracdet /= nfine_per_frac
 
-        fracdet_cov_map = HealSparseCoverage.make_from_pixels(self.nside_coverage,
-                                                              nside,
-                                                              np.where(cov_mask)[0])
+        fracdet_cov_map = HealSparseCoverage.make_from_pixels(
+            self.nside_coverage,
+            nside,
+            coverage_pixels_ordered,
+        )
 
         # The sentinel for a fracdet_map is 0.0, no coverage.
         return HealSparseMap(cov_map=fracdet_cov_map, sparse_map=fracdet,

--- a/tests/test_fracdet_map.py
+++ b/tests/test_fracdet_map.py
@@ -155,6 +155,42 @@ class FracdetTestCase(unittest.TestCase):
             dtype=np.bool_,
         )
         sparse_map[0: 12345] = True
+        sparse_map[100000: 105023] = True
+        # Create some pixels and blank them.
+        sparse_map[50000: 60000] = True
+        sparse_map[50000: 60000] = False
+
+        fracdet_map1 = sparse_map.fracdet_map(nside_coverage)
+
+        np.testing.assert_array_almost_equal(fracdet_map1[:], sparse_map.coverage_map)
+
+        # Test that the fracdet map is good for target nside
+        fracdet_map2 = sparse_map.fracdet_map(nside_fracdet)
+
+        full_map = sparse_map[:].astype(np.int32)
+        nfine_per_frac = 2**healsparse.utils._compute_bitshift(nside_fracdet, nside_map)
+        full_map = full_map.reshape((full_map.size // nfine_per_frac, nfine_per_frac))
+        fracdet_recompute = full_map.sum(axis=1) / nfine_per_frac
+
+        np.testing.assert_array_almost_equal(fracdet_map2[:], fracdet_recompute)
+
+    def test_fracdet_map_bitpacked_bool(self):
+        """Test fracdet_map with a boolean map."""
+        nside_coverage = 16
+        nside_fracdet = 32
+        nside_map = 512
+
+        sparse_map = healsparse.HealSparseMap.make_empty(
+            nside_coverage,
+            nside_map,
+            dtype=np.bool_,
+            bit_packed=True,
+        )
+        sparse_map[0: 12345] = True
+        sparse_map[100000: 105023] = True
+        # Create some pixels and blank them.
+        sparse_map[50000: 60000] = True
+        sparse_map[50000: 60000] = False
 
         fracdet_map1 = sparse_map.fracdet_map(nside_coverage)
 

--- a/tests/test_fracdet_map.py
+++ b/tests/test_fracdet_map.py
@@ -143,6 +143,33 @@ class FracdetTestCase(unittest.TestCase):
 
         np.testing.assert_array_almost_equal(fracdet_map2[:], fracdet_map_orig)
 
+    def test_fracdet_map_bool(self):
+        """Test fracdet_map with a boolean map."""
+        nside_coverage = 16
+        nside_fracdet = 32
+        nside_map = 512
+
+        sparse_map = healsparse.HealSparseMap.make_empty(
+            nside_coverage,
+            nside_map,
+            dtype=np.bool_,
+        )
+        sparse_map[0: 12345] = True
+
+        fracdet_map1 = sparse_map.fracdet_map(nside_coverage)
+
+        np.testing.assert_array_almost_equal(fracdet_map1[:], sparse_map.coverage_map)
+
+        # Test that the fracdet map is good for target nside
+        fracdet_map2 = sparse_map.fracdet_map(nside_fracdet)
+
+        full_map = sparse_map[:].astype(np.int32)
+        nfine_per_frac = 2**healsparse.utils._compute_bitshift(nside_fracdet, nside_map)
+        full_map = full_map.reshape((full_map.size // nfine_per_frac, nfine_per_frac))
+        fracdet_recompute = full_map.sum(axis=1) / nfine_per_frac
+
+        np.testing.assert_array_almost_equal(fracdet_map2[:], fracdet_recompute)
+
     def test_fracdet_map_raises(self):
         """
         Test limitations of fracdet_map


### PR DESCRIPTION
There was a bug where the fracdet map was garbage when the coverage pixels were out-of-order in memory.  This fixes the bug and also simplifies the code paths between the fracdet map and the coverage map.